### PR TITLE
Hotfix search footer

### DIFF
--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -620,8 +620,7 @@ span.th-sub {
 
 .related-reading {
     padding: 100px 0;
-    background-image: url("/IndicatorPublic/beta/images/report_bottom_background.jpg");
-    background-image: url("/EH-dataportal/images/report_bottom_background.jpg");
+    background-image: url("/IndicatorPublic/beta/images/report_bottom_background.jpg"), url("/EH-dataportal/images/report_bottom_background.jpg");
     background-repeat: no-repeat;
     background-size: cover;
     border-top: 4px solid $primary;

--- a/themes/dohmh/layouts/search-results/single.html
+++ b/themes/dohmh/layouts/search-results/single.html
@@ -33,24 +33,37 @@
         <hr />
       </div>
 
-      <hr class="my-2">
-      <p><i class="fas fa-exclamation-circle mr-1"></i><em>Can't find what you're looking for?</em> 
-
-        <a href='{{ ref . "/content/data-explorer/all-data.md" }}'>Browse an index of all our datasets</a>
-        
-      <p>Or, try these other Health Department resources:
-      <ul>
-        <li><a href="https://a816-health.nyc.gov/hdi/epiquery/">EpiQuery</a>: Analyze and visualize NYC health data from surveys, disease reports and vital records by sex, race/ethnicity, age and other stratifications.
-        </li>
-        <li><a href="https://a816-health.nyc.gov/hdi/profiles/">Community Health Profiles</a>: Learn about the social, economic and health conditions and outcomes of New Yorkers, neighborhood-by-neighborhood.
-        </li>
-      </ul>
-      <a href="https://www1.nyc.gov/site/doh/data/data-home.page">Browse all Health Department data resources here</a>.
-      </p>
-
     </div>
     
   </article>
+
+  <section class="related-reading">
+    <div class="container">
+      <div class="row">
+        <div class="col-10 mx-auto">
+          <div class="card bg-white text-green mb-2 p-2 text-primary fs-lg">
+             <strong class="border-bottom"><i class="fas fa-exclamation-circle mr-1"></i>Can't find what you're looking for?</strong>
+          </div>
+
+          <div class="card bg-white text-green mb-2 p-2 text-black fs-rg">
+            <p>
+            <a href='{{ ref . "/content/data-explorer/all-data.md" }}'>Browse an index of all of the datasets on the Environment & Health Data Portal</a>: .</p>
+            <p>Or, try these other Health Department resources:
+            <ul>
+              <li><a href="https://a816-health.nyc.gov/hdi/epiquery/">EpiQuery</a>: Analyze and visualize NYC health data from surveys, disease reports and vital records by sex, race/ethnicity, age and other stratifications.
+              </li>
+              <li><a href="https://a816-health.nyc.gov/hdi/profiles/">Community Health Profiles</a>: Learn about the social, economic and health conditions and outcomes of New Yorkers, neighborhood-by-neighborhood.
+              </li>
+            </ul>
+          </p><p>
+            <a href="https://www1.nyc.gov/site/doh/data/data-home.page">See all Health Department data resources here</a>.
+            </p>
+         </div>
+      </div>
+
+      </div>
+    </div>
+  </section>
 
 {{- end -}}
 


### PR DESCRIPTION
Bringing the search footer (related results / "can't find what you're looking for?") into consistent styles with other related-footers, plus fixing the background-image fallback for different site paths. 