### PR TITLE
Hotfix citation url

### DIFF
--- a/themes/dohmh/layouts/data-explorer/single.html
+++ b/themes/dohmh/layouts/data-explorer/single.html
@@ -2825,7 +2825,7 @@
         today = mm + '/' + dd + '/' + yyyy;
 
         // Create citation
-        let citation = "New York City Department of Health, Environment & Health Data Portal. "  + `{{ .Title }}` + " data. " + indicatorName + '. Accessed at ' + `{{ .RelPermalink}}` + ' on ' + today + "."
+        let citation = "New York City Department of Health, Environment & Health Data Portal. "  + `{{ .Title }}` + " data. " + indicatorName + '. Accessed at ' + `{{ .Permalink}}` + ' on ' + today + "."
 
         // Add to form
         document.getElementById('citeText').setAttribute('value',citation);


### PR DESCRIPTION
Using `Permalink` instead of `RelPermalink` in the citation function so that we get full URLs in the citation copy, instead of:

`New York City Department of Health, Environment & Health Data Portal. "Economic conditions" data. Poverty. Accessed at "/data-explorer/economic-conditions/" on 10/24/2022.`