### PR TITLE
fix RTAQ Github and NYCCAS link

### DIFF
--- a/themes/dohmh/layouts/key-topics/realtime.html
+++ b/themes/dohmh/layouts/key-topics/realtime.html
@@ -43,7 +43,7 @@
                 <strong>About the Data</strong>
                 <p>Data are hourly measurements of PM2.5, in micrograms per cubic meter of air (µg/m<sup>3</sup>).</p>
     
-                <p>Data come from the NYCCAS near-real-time monitor network. External factors can sometimes affect monitor functioning; these data are preliminary and subject to change. <a href="{{ site.Params.data_repo }}{{ site.Params.data_branch }}/key-topics/real-time-air-quality" target="_blank">Download these data on Github</a>.</p>
+                <p>Data come from the NYCCAS near-real-time monitor network. External factors can sometimes affect monitor functioning; these data are preliminary and subject to change. <a href="https://github.com/nychealth/EHDP-data/tree/production/key-topics/real-time-air-quality" target="_blank">Download these data on Github</a>.</p>
             </div>
              </div>
     </div>
@@ -153,7 +153,7 @@
                     <p>Building density affects a neighborhood's air quality because like vehicles, buildings
                         burn fuel and emit pollutants: their boilers burn oil and gas to produce heat and hot
                         water. This is one reason we often see more air pollution in the winter. Because of new heating oil regulations, PM2.5 has gone down dramatically, and SO2 levels
-                        are now indetectable. <a href="https://nyccas.cityofnewyork.us/report">Read more at
+                        are now indetectable. <a href="../nyccas">Read more at
                             the NYCCAS annual report</a>. </p>
     
                     <h4 class="card-title"><i class="fas fa-industry mr-1" aria-hidden="true"></i>Industrial area


### PR DESCRIPTION
Heya - CH identified a bad link. I fixed by removing the site variables. These were trying to deliver a raw github file (`site.Params.data_repo` = `https://raw.githubusercontent.com/nychealth/EHDP-data`) instead of the repo directory location, but I think the hardcoded URL works fine here since it brings people to the directory with the readme on the rtaq data. Mind taking a quick look before merging on in? 

Then, a handful of things will be ready for deployment. 

I also used this as an opportunity to brief AM on our workflow - branching, naming, and the very high-level of hugo functioning. 

