### PR TITLE
Hotfix robots tag

### DIFF
--- a/themes/dohmh/layouts/partials/head.html
+++ b/themes/dohmh/layouts/partials/head.html
@@ -9,6 +9,10 @@
     gtag('config', 'G-64BWDRHRGB');
 </script>
 
+<!-- Google will index this page -->
+<meta name="robots" content="all" />
+
+
 {{ else if eq hugo.Environment "development"}}
 
 <!-- Google won't index this page or follow links -->

--- a/themes/dohmh/layouts/partials/seo.html
+++ b/themes/dohmh/layouts/partials/seo.html
@@ -1,7 +1,6 @@
 <!-- Standard SEO -->
 <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Data.globals.seo_defaults.seo_description }}{{- end -}}">
 <link rel="canonical" href="{{ .Permalink }}" />
-<meta name="robots" content="all" />
 <meta name="geo.region" content="" />
 <meta name="geo.placename" content="{{ .Site.Title }}" />
 


### PR DESCRIPTION
Setting robots tag so that `content="all"` is on production but `noindex, nofollow` is on development. 