### PR TITLE
giving CDTA unique georank

### DIFF
--- a/assets/js/data-explorer/global.js
+++ b/assets/js/data-explorer/global.js
@@ -119,11 +119,11 @@ const assignGeoRank = (GeoType) => {
         case 'CD':
             return 6;
         case 'CDTA2020':
-            return 6;
+            return 7;
         case 'NTA2010':
-            return 7;
+            return 8;
         case 'NTA2020':
-            return 7;
+            return 8;
     }
 }
 


### PR DESCRIPTION
making CDTA georank distinct from CD georank, allowing CDTA to display correctly (i.e., separately from CDTA) in summary data table