### PR TITLE
modal wider, limit index content

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -43,3 +43,17 @@ table {
     margin-top: .75rem !important;
   }
 }
+
+
+#searchModal .modal-dialog{
+  overflow-y: initial !important;
+}
+#searchModal .modal-body{
+  height: 75vh;
+  overflow-y: auto;
+}
+
+#searchModal .pagefind-ui__filter-block {
+  position: sticky;
+  top: 0;
+}

--- a/themes/dohmh/layouts/_default/baseof.html
+++ b/themes/dohmh/layouts/_default/baseof.html
@@ -5,34 +5,34 @@
   {{ block "js_top" . -}}{{- end -}}
 </head>
 <body>
-  
+
   <!--
-    For data stories: 
+    For data stories:
     - Regular Pages (individual data stories) to have header-ds.html
     - DS landing page & all others to have header.html
   -->
-  
+
   {{- if or (ne .Section "data-stories") ( eq .RelPermalink "/data-stories/") -}}
   {{- partial "header.html" . -}}
   {{- end -}}
-  
-  
+
+
   {{- if and (eq .Section "data-stories") ( ne .RelPermalink "/data-stories/") -}}
   {{- partial "header-ds.html" . -}}
   {{- end -}}
-  
-  <main id="skip-header-target" role="main">
+
+  <main id="skip-header-target" role="main" data-pagefind-body>
     {{- block "main" . -}}{{- end -}}
     <ul id="results"></ul>
   </main>
-  
+
   {{/*  put conditional modal JS and CSS at the bottom of every page  */}}
-  
+
   {{- partial "conditional-modal.html" -}}
-  
+
   {{- partial "footer.html" . -}}
   {{- partial "js_bottom.html" -}}
   {{- block "js_bot" . -}}{{- end -}}
-  
+
 </body>
 </html>

--- a/themes/dohmh/layouts/location/single.html
+++ b/themes/dohmh/layouts/location/single.html
@@ -128,7 +128,7 @@
     var data_download_loc = "{{ .data_download_loc }}"
 </script>
 
-<section class="container-fluid pl-lg-6" id="skip-header-target">
+<section class="container-fluid pl-lg-6" id="skip-header-target" data-pagefind-ignore>
     <div class="row">
 
         <div class="col-lg-3 collapse d-lg-block sidebar-report d-print-none" id="sidebar-nav">

--- a/themes/dohmh/layouts/neighborhood-reports/topiclanding.html
+++ b/themes/dohmh/layouts/neighborhood-reports/topiclanding.html
@@ -30,7 +30,7 @@
                       </div>
                     </div>
                     <div class="col-4">
-                      <button type="submit" class="btn-primary btn btn-block">Get Report</button> 
+                      <button type="submit" class="btn-primary btn btn-block">Get Report</button>
                     </div>
                   </div>
                 </form>
@@ -69,7 +69,7 @@
 {{/* ====  save indicator names as a resource  ==== */}}
 
 {{- /* ----  get indicators.json from data repo, and transform into a Hugo object  ---- */ -}}
-  
+
   {{- $nr_indicator_names := (resources.GetRemote (print site.Params.data_repo site.Params.data_branch "/neighborhood-reports/data/nr_indicator_names.json")) | transform.Unmarshal -}}
 
   {{- $nr_indicator_names_json := $nr_indicator_names | jsonify (dict "indent" "  ") | resources.FromString "/IndicatorData/nr_indicator_names.json" -}}
@@ -92,24 +92,24 @@
   <script type="text/javascript" src="{{ $secureJS.RelPermalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
 
 
-<script type="text/javascript"> 
+<script type="text/javascript">
     // https://www.aspsnippets.com/Articles/Populate-DropDownList-from-JSON-Array-using-JavaScript.aspx
     function PopulateDropDownList() {
           //Build an array containing Neighborhood records.
           //UHFList.js contains a variable 'neighborhoods' with names zips and ids
-          
+
            var ddlNeighborhoods = document.getElementById("last-neighborhood");
-          
+
            //Add the Options to the DropDownList.
            for (var i = 0; i < neighborhoods.length; i++) {
                var option = document.createElement("OPTION");
-  
+
                //Set Neighborhood Name in Text part.
                option.innerHTML = neighborhoods[i].namezip;
-  
+
                //Set Neighborhood Id in Value part.
                option.value = neighborhoods[i].page_name;
-  
+
                //Add the Option element to DropDownList.
                ddlNeighborhoods.options.add(option);
            }
@@ -125,7 +125,7 @@
        minLength: 2,
        selectElement: selectEl
      })
-  
+
     // this takes the AA form and on submit, sends page to a new location.
     var searchForm = document.getElementById('last-neighborhood-select') // this isn't all-data, but all-data-select because of changes applied by the AA JS.
     document.querySelector('form.autocomplete-form').addEventListener("submit", function (e) {

--- a/themes/dohmh/layouts/partials/footer.html
+++ b/themes/dohmh/layouts/partials/footer.html
@@ -187,7 +187,7 @@
 
 <!-- Modal -->
 <div class="modal fade" id="searchModal" tabindex="-1" role="dialog" aria-labelledby="searchModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-xl" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="searchModalLabel">Search</h5>


### PR DESCRIPTION
This PR addresses the following:

1. wider modal
2. check pagefind version and upgrade if needed
3. rework the scroll on the modal
4. exclude the individual reports for neighborhoods
5. instead, let’s show a page like this in the search results - https://a816-dohbesp.nyc.gov/IndicatorPublic/beta/neighborhood-reports/downtown_heights_slope/

@mmontesanonyc @cgettings Seth was hoping to be able to review this work at a public URL. Is there a URL that exists on your end to review?