### PR TITLE
Hotfix-breadcrumb-topic-modal (prod)

### DIFF
--- a/themes/dohmh/layouts/data-explorer/single.html
+++ b/themes/dohmh/layouts/data-explorer/single.html
@@ -247,7 +247,7 @@
                     <li class="breadcrumb-item"><a href={{ relURL "" }}>Home</a></li>
                     <li class="breadcrumb-item"><a href={{ relURL "data-explorer" }}>Data Explorer</a></li>
                     <li class="breadcrumb-item">{{ .Title }}&nbsp;
-                        <button type="button" class="btn btn-outline-primary badge" data-toggle="modal" data-target="#topicModal">
+                        <button type="button" class="btn btn-outline-light text-primary badge" data-toggle="modal" data-target="#topicModal">
                             <i class="fas fa-ellipsis-h font-weight-bold" aria-hidden="true"></i>
                         </button></li>
                 </ul>

--- a/themes/dohmh/layouts/data-explorer/single.html
+++ b/themes/dohmh/layouts/data-explorer/single.html
@@ -247,8 +247,13 @@
                     <li class="breadcrumb-item"><a href={{ relURL "" }}>Home</a></li>
                     <li class="breadcrumb-item"><a href={{ relURL "data-explorer" }}>Data Explorer</a></li>
                     <li class="breadcrumb-item">{{ .Title }}&nbsp;
-                        <button type="button" class="btn btn-outline-light text-primary badge" data-toggle="modal" data-target="#topicModal">
-                            <i class="fas fa-ellipsis-h font-weight-bold" aria-hidden="true"></i>
+                        <button type="button" 
+                            class="btn btn-outline-light text-primary badge" 
+                            title="Change topic"
+                            data-toggle="modal" 
+                            data-target="#topicModal"
+                            aria-labelledby="topicModalLabel"
+                        ><i class="fa-solid fa-arrow-right-arrow-left font-weight-bold" aria-hidden="true"></i>
                         </button></li>
                 </ul>
             </nav>

--- a/themes/dohmh/layouts/data-explorer/single.html
+++ b/themes/dohmh/layouts/data-explorer/single.html
@@ -246,9 +246,9 @@
                 <ul class="breadcrumb mr-auto">
                     <li class="breadcrumb-item"><a href={{ relURL "" }}>Home</a></li>
                     <li class="breadcrumb-item"><a href={{ relURL "data-explorer" }}>Data Explorer</a></li>
-                    <li class="breadcrumb-item"><button type="button" class="btn btn-sm btn-outline-light text-primary" data-toggle="modal"
-                        data-target="#topicModal">
-                        <i class="fas fa-ellipsis-h font-weight-bold" aria-hidden="true"></i>
+                    <li class="breadcrumb-item">{{ .Title }}&nbsp;
+                        <button type="button" class="btn btn-outline-primary badge" data-toggle="modal" data-target="#topicModal">
+                            <i class="fas fa-ellipsis-h font-weight-bold" aria-hidden="true"></i>
                         </button></li>
                 </ul>
             </nav>

--- a/themes/dohmh/layouts/data-explorer/single.html
+++ b/themes/dohmh/layouts/data-explorer/single.html
@@ -246,7 +246,7 @@
                 <ul class="breadcrumb mr-auto">
                     <li class="breadcrumb-item"><a href={{ relURL "" }}>Home</a></li>
                     <li class="breadcrumb-item"><a href={{ relURL "data-explorer" }}>Data Explorer</a></li>
-                    <li class="breadcrumb-item">{{ .Title }}&nbsp;
+                    <li class="breadcrumb-item">{{ .Title }}
                         <button type="button" 
                             class="btn btn-outline-light text-primary badge" 
                             title="Change topic"
@@ -257,7 +257,7 @@
                         </button></li>
                 </ul>
             </nav>
-            <div class="float-right pr-4 d-sm-none d-md-block">
+            <div class="float-right pr-4 d-none d-md-block">
                 {{- partial "socialshare" . -}}
             </div>
             <h1 class="h2">{{ .Title }} </h1>


### PR DESCRIPTION
The topic switcher button in the breadcrumbs has felt weird since we changed it: there's nothing that really indicates that it's a topic switcher, except being to the right of the Data Explorer section title. So, I added the title back, which gives a stronger hint about what the button does.

I also added the `badge` class to fix the vertical alignment, which was a lot more annoying when showing the full topic title.