### PR TITLE
revise RTAQ download popup

### DIFF
--- a/themes/dohmh/layouts/partials/realtime-download.html
+++ b/themes/dohmh/layouts/partials/realtime-download.html
@@ -99,7 +99,7 @@
     // get today's date values
     const date = new Date();
     let thisMonth = date.getMonth() + 1;
-    let availMonth = date.getMonth()
+    let availMonth = date.getMonth();
     let thisYear = date.getFullYear();
     
     // set up defaults
@@ -108,8 +108,8 @@
         var chosenYear
         var chosenMonth
         if (availMonth == 0) {
-            chosenYear = thisYear - 1
-            chosenMonth = 12
+            chosenYear = thisYear
+            chosenMonth = 1
             console.log('jan: ',chosenYear,chosenMonth)
         } else {
             chosenYear = thisYear
@@ -151,8 +151,8 @@
         } else {}
     
         // if 2023, inactivate anything after last month
-        if (chosenYear == thisYear && chosenMonth > availMonth) {
-            alert('You cannot download data for present or future months. Please select a month in the past.')
+        if (chosenYear == thisYear && chosenMonth > thisMonth) {
+            alert('You cannot download data for future months.')
         } else {}
     
     }


### PR DESCRIPTION
NB: previous RTAQ popup said "you cannot download data for current or future months." However, download files populate daily now; somebody can download data for the current month. Revising functionality and alert accordingly. 

PR checklist:
- [x] Changes previewed and QC'ed
- [ ] In PR, mention team member for FYI, review, or approval

New content (if applicable):
- [ ] Date updated
- [ ] Tags and keywords updated
- [ ] Feature box updated
- [ ] Adding the new content to `related` or `relatedData` for things it's related to

New data (if applicable)
- [ ] Added to Recently Updated
- [ ] Added to 311-crosswalk