### PR TITLE
remove trailing divider keywords/311

### DIFF
--- a/assets/js/data-explorer/data.js
+++ b/assets/js/data-explorer/data.js
@@ -1029,7 +1029,8 @@ function draw311Buttons(indicator_id) {
             for (let i = 0; i < filteredCrosswalk.length; i ++ ) {
                 let title = filteredCrosswalk[i].topic
                 let destination = filteredCrosswalk[i].kaLink
-                let btn = `<a href="https://portal.311.nyc.gov/article/?kanumber=${destination}" class="mr-1" target="_blank" rel="noopener noreferrer">${title}</a>| `
+                let divider = i < filteredCrosswalk.length - 1 ? '| ' : ''
+                let btn = `<a href="https://portal.311.nyc.gov/article/?kanumber=${destination}" class="mr-1" target="_blank" rel="noopener noreferrer">${title}</a>${divider}`
                 dest.forEach(element => element.innerHTML += btn)
             }
     })

--- a/themes/dohmh/layouts/partials/keywords.html
+++ b/themes/dohmh/layouts/partials/keywords.html
@@ -2,7 +2,7 @@
 {{- if .Params.keywords -}}
 <h5 class="font-weight-bold keywords fs-sm">Keywords:</h5>
     <div class="fs-xs">
-        {{- range .Params.keywords -}}<a class="" href="{{ "keywords/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a> |&#32;
+        {{- range $i, $kw := .Params.keywords -}}{{- if $i }} | {{ end -}}<a class="" href="{{ "keywords/" | relLangURL }}{{ $kw | urlize }}/">{{ $kw }}</a>
         {{- end -}}
     </div>
 


### PR DESCRIPTION
Long awaited fix:
<img width="670" height="396" alt="image" src="https://github.com/user-attachments/assets/6866cf49-3e75-4f1a-ac6e-6e2daa9d5706" />
<img width="632" height="308" alt="image" src="https://github.com/user-attachments/assets/23cea048-deb2-4ed3-9296-a5aa2484620b" />


PR checklist:
- [ ] Changes previewed and QC'ed
- [ ] In PR, mention team member for FYI, review, or approval

New content (if applicable):
- [ ] Date updated
- [ ] Tags and keywords updated
- [ ] Feature box updated
- [ ] Adding the new content to `related` or `relatedData` for things it's related to

New data (if applicable)
- [ ] Added to Recently Updated
- [ ] Added to 311-crosswalk
- [ ] Comparisons and Links reviewed for additions