### PR TITLE
Refactor neighborhood report SPA and improve print layout

### DIFF
--- a/.claude/commands/js-development.md
+++ b/.claude/commands/js-development.md
@@ -1,0 +1,166 @@
+---
+name: js-development
+description: Vanilla JavaScript conventions for this project — module scope, const/let, arrow functions, 4-space indentation, vertical whitespace, and comment style. Use when writing or editing any .js file.
+---
+
+# Vanilla JavaScript conventions
+
+## Scope — no IIFEs
+
+Do not wrap code in an immediately-invoked function expression. `let` and `const`
+at the top level of a script do not create `window.*` properties, so an IIFE adds
+no safety benefit over just writing module-level declarations.
+
+When a value genuinely needs to be reachable from outside the file, expose it
+explicitly:
+
+```js
+// expose one function; everything else stays file-scoped
+window.nrDownloadCSV = downloadCSV;
+```
+
+## Variables — `const` and `let`
+
+- Use `const` by default.
+- Use `let` only when the binding is reassigned.
+- Never use `var`.
+
+```js
+// good
+const config = window.NR_TOPIC_SPA_CONFIG;
+let currentNeighborhood = '';
+
+// bad
+var config = window.NR_TOPIC_SPA_CONFIG;
+```
+
+## Functions — named arrow functions
+
+Prefer named arrow functions assigned to `const` over `function` declarations.
+
+```js
+// good
+const getTertileLabel = (rank, rankReverse) => {
+    ...
+};
+
+// bad
+function getTertileLabel(rank, rankReverse) {
+    ...
+}
+```
+
+Use a `function` declaration only when you specifically need hoisting or a `this`
+binding — document why if you do.
+
+Inline callbacks use arrow functions:
+
+```js
+rows.forEach(row => {
+    ...
+});
+
+fetch(url)
+    .then(res => res.json())
+    .then(data => { ... });
+```
+
+Single-expression bodies can drop braces and `return`:
+
+```js
+const styleFeature = () => defaultStyle;
+const el = id => document.getElementById(id);
+```
+
+## Indentation — 4 spaces
+
+Use 4 spaces per indent level. No tabs.
+
+## Vertical whitespace
+
+Add a blank line between logical groups within a function body and before each
+`return`. Functions should breathe — a reader should be able to scan and
+immediately see the distinct phases.
+
+```js
+const renderSection = (section, neighborhoodName) => {
+
+    // Section containers are layout-driven and may be absent in some templates
+    const container = document.getElementById(section.containerId);
+
+    if (!container) {
+        return;
+    }
+
+    // Neighborhood-level rows are pre-grouped during loadSection
+    const byNeighborhood = sectionData[section.id] || {};
+    const rows = byNeighborhood[neighborhoodName] || [];
+
+    container.innerHTML = '';
+
+    if (!rows.length) {
+        container.innerHTML =
+            '<p class="text-muted px-2 pb-2 mb-0">No data available for this neighborhood.</p>';
+        return;
+    }
+
+    rows.forEach(row => {
+
+        const card = document.createElement('div');
+        card.innerHTML = buildIndicatorCard(row, section.id, neighborhoodName);
+        container.appendChild(card);
+
+    });
+
+};
+```
+
+Inside `forEach`, `then`, and similar callbacks: add a blank line after the
+opening brace and before the closing brace when the body is more than one line.
+
+## Comments
+
+Add a short comment before each function explaining its purpose. Add inline
+comments before non-obvious branches or variable groups — focus on *why*, not
+*what*.
+
+```js
+// Normalize rank values that may arrive as numbers or strings
+const r = String(rank);
+// rankReverse indicates indicators where lower values are directionally better
+const reverse = rankReverse === true || rankReverse === 'true';
+```
+
+Do not end comments with a period. Keep them to one line where possible.
+
+## console.log format
+
+Use a structured `'scope: event: value'` format for trace logs so they are
+greppable and easy to filter:
+
+```js
+console.log('renderSection: enter:', { sectionId: section.id, neighborhoodName });
+console.log('renderSection: branch-missing-container:', section.containerId);
+console.log('bootstrap: start');
+```
+
+## HTML string indentation
+
+When building HTML via string concatenation, indent each nested element to
+reflect the actual DOM hierarchy:
+
+```js
+const headerHTML =
+    '<div class="card-header" id="' + headingId + '">' +
+        '<h2 class="mb-0">' +
+            '<button class="btn" type="button" ' +
+                'data-toggle="collapse" data-target="#' + collapseId + '">' +
+                '<div class="row">' +
+                    '<div class="col-7">' +
+                        '<span>' + row.indicator_short_name + '</span>' +
+                    '</div>' +
+                '</div>' +
+            '</button>' +
+        '</h2>' +
+    '</div>';
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+NYC Department of Health & Mental Hygiene's [Environment & Health Data Portal](https://a816-dohbesp.nyc.gov/IndicatorPublic/) — a Hugo static site providing public access to environmental and health indicators through data stories, an interactive data explorer, neighborhood reports, and topic pages.
+
+Most indicator data lives in the separate [EHDP-data](https://github.com/nychealth/EHDP-data) repository (not this repo). Site code fetches it at build time via `data_branch` config variable and at runtime via `data_repo` param in Hugo templates/JS.
+
+## Commands
+
+```bash
+# Install JS dependencies (includes hugo-extended)
+npm install
+
+# Local development (uses production data branch)
+hugo serve --environment development
+
+# Local dev with staging data
+hugo serve --environment dev_stage
+
+# Build to docs/ for production
+hugo --environment production
+
+# Create new content
+hugo new data-stories/TITLE/index.md
+hugo new key-topics/TITLE/index.md
+```
+
+Browse locally at http://localhost:1313/EH-dataportal
+
+## Environments
+
+Specify with `--environment ENV`. Each merges `config/ENV/config.toml` over `config/_default/config.toml`.
+
+| Environment   | Data branch | Purpose                              |
+|---------------|-------------|--------------------------------------|
+| `development` | production  | Preview site changes (default local) |
+| `dev_stage`   | staging     | Preview combined site + data changes |
+| `production`  | production  | Deploy to production servers         |
+| `prod_stage`  | staging     | Preview data changes only            |
+| `local_prod`  | production  | Uses locally hosted data repo        |
+| `local_stage` | staging     | Uses locally hosted data repo        |
+
+Key per-environment variables: `baseURL` and `data_branch`.
+
+## Architecture
+
+### Hugo structure
+
+- `content/` — Markdown content files with YAML frontmatter
+- `themes/dohmh/layouts/` — Hugo templates (mirrors `content/` structure)
+- `themes/dohmh/layouts/_default/baseof.html` — Root template: head, header, main, footer, JS
+- `themes/dohmh/layouts/partials/` — Reusable template blocks
+- `themes/dohmh/layouts/shortcodes/` — Shortcodes callable from markdown content
+- `assets/` — SCSS, JS, images (processed by Hugo with SRI fingerprinting)
+- `static/` — Unprocessed files served as-is
+- `data/globals/` — YAML data accessible throughout templates (featured data, NR specs, SEO vars)
+
+### Layout routing
+
+- `_index.md` → `section.html` (section landing pages)
+- `index.md` or `name.md` → `single.html`
+- Frontmatter `layout: custom` → `custom.html` in the section's layouts folder
+
+### JS architecture
+
+JS files under `assets/js/` are fingerprinted and served with Subresource Integrity. Dependencies from `node_modules` are mounted into `assets/node_modules` via Hugo module mounts — they are bundled locally, not loaded from CDNs.
+
+The Data Explorer JS is split by view: `assets/js/data-explorer/app.js`, `map.js`, `trend.js`, `table.js`, `links.js`, `disparities.js`, `data.js`, `measures.js`, `global.js`, `print.js`.
+
+`assets/js/nr-topic-spa.js` drives the Phase 2 Neighborhood Reports topic SPA.
+
+### SCSS
+
+`assets/scss/theme.scss` is the root entrypoint, importing Bootstrap overrides and custom styles in lettered files (`_a-global-variables.scss` through `_h-nyc-subway-icons.scss`). Bootstrap itself is mounted from `node_modules`.
+
+### Content sections
+
+| Section | Layout folder | Notes |
+|---------|---------------|-------|
+| `data-stories` | `layouts/data-stories/` | Markdown articles with Vega/Datawrapper shortcode embeds |
+| `data-explorer` | `layouts/data-explorer/` | Each topic MD lists `indicators` array; JS drives all visualization |
+| `neighborhood-reports` | `layouts/neighborhood-reports/` | JSON spec per neighborhood in EHDP-data; `nr-topic-spa.html` is Phase 2 |
+| `key-topics` | `layouts/key-topics/` | Organizing principle; linked via `categories` frontmatter |
+| `data-features` | `layouts/data-features/` | Feature articles/tools |
+
+### Data flow
+
+- **Build time**: Hugo fetches remote JSON/YAML from EHDP-data via `getresource` (controlled by `data_branch` and `maxAge` in config). `data-index.html` generates `topic_indicators.json` cross-referencing topics and indicators.
+- **Runtime**: JS reads `data_repo` and `data_branch` Hugo params to fetch indicator data, map specs, and Vega specs directly from EHDP-data GitHub raw URLs.
+
+### Content relationships
+
+- `categories` frontmatter links content to Key Topics (`keyTopic` field)
+- `keywords` feeds Pagefind site search
+- `related` and `relatedData` frontmatter fields specify manual cross-links; templates default to category-matched content when these are absent
+
+### Shortcodes
+
+Available in markdown content files:
+- `vega` / `vega0` — embed Vega-Lite specs from EHDP-data
+- `datawrapper` — embed Datawrapper charts
+- `accordion` — collapsible content sections
+- `csvtable`, `rawhtml`, `storyheader`, `updateflag`
+
+### Multi-language
+
+Site has English (`en`), Spanish (`es`), and Simplified Chinese (`zh`). Localized home pages use `_index.es.md` / `_index.zh.md` naming. `ignoreFiles` in config.toml gates language-specific content from the default build.
+
+### Subresource Integrity (SRI)
+
+Hugo calculates integrity hashes for all local JS/CSS resources using the `short-fingerprint.html` partial (a custom hash-shortening wrapper around Hugo's built-in `integrity` function). If SRI breaks on production, check that end-of-line characters are Unix `LF` — the GitHub Actions workflows enforce this on merge.
+
+### CloudCannon CMS
+
+`cloudcannon.config.yaml` and `.cloudcannon/` configure the CMS editor interface. `.cloudcannon/schemas/` contains frontmatter templates for editor-created content.
+
+## Deployment
+
+Branches are auto-built by GitHub Actions on merge:
+- `production` → builds to `builds/prod-prod` (live site)
+- `build-to-dev-stage` → builds to `builds/dev-stage` (staging)
+
+Branch naming convention: `hotfix-[NAME]`, `content-[NAME]`, `feature-[NAME]`. Branch from `production`; merge to `development` for testing, then to `production` to deploy.
+
+## JavaScript
+
+When writing or editing any `.js` file in this project, load and follow the `/js-development` command.
+
+## Common gotchas
+
+- **Missing images cause build failures.** Hugo resizes images at build time; a missing source image will abort the build.
+- **Build caching.** Remote EHDP-data resources can be cached. Set `maxAge = 0` in config to disable if updates aren't appearing in a build.
+- **SRI + line endings.** Integrity hash mismatches on production usually mean `CRLF` line endings snuck in. GitHub Actions normalizes these on merge.

--- a/assets/js/nr-topic-spa.js
+++ b/assets/js/nr-topic-spa.js
@@ -397,7 +397,7 @@ const init = () => {
                 '<button class="btn btn-block btn-sm text-left" type="button" ' +
                     'data-toggle="collapse" data-target="#' + collapseId + '" ' +
                     'aria-expanded="false" aria-controls="' + collapseId + '">' +
-                    '<div class="row no-gutters d-print-none" style="width:100%">' +
+                    '<div class="row no-gutters" style="width:100%">' +
                         '<div class="col-7">' +
                             '<span class="font-weight-bold fs-md">' + (row.indicator_short_name || '') + '</span><br>' +
                             '<span class="fs-sm font-weight-normal">' + (row.indicator_long_name || '') + '</span>' +

--- a/assets/js/nr-topic-spa.js
+++ b/assets/js/nr-topic-spa.js
@@ -55,32 +55,81 @@ const init = () => {
 
     const getNeighborhoodFromURL = () => {
 
-        const params = new URLSearchParams(window.location.search);
+        // Two-step lookup for the active neighborhood on page load.
+        //
+        // Step 1 — path: handles externally shared or bookmarked URLs like
+        //   /neighborhood-reports/asthma_and_the_environment/east_new_york
+        // On production, IIS rewrites these to serve the topic page, and the slug
+        // is still visible in the path for us to read here.
+        const config = window.NR_TOPIC_SPA_CONFIG;
+        const pathParts = window.location.pathname.replace(/\/$/, '').split('/').filter(Boolean);
+        const slug = pathParts[pathParts.length - 1];
 
-        return params.get('neighborhood') || '';
+        if (config.neighborhoodMap[slug]) {
+            return config.neighborhoodMap[slug];
+        }
+
+        // Step 2 — sessionStorage: handles internal navigation from the landing page,
+        // topic tabs, neighborhood cards, and the 404 fallback. Each of those entry
+        // points stores the neighborhood slug before navigating to the clean topic URL,
+        // so the page load never hits the server with a neighborhood in the path.
+        // The item is consumed immediately so it doesn't bleed into subsequent page loads.
+        const pending = sessionStorage.getItem('nr_pending_neighborhood');
+        if (pending && config.neighborhoodMap[pending]) {
+            sessionStorage.removeItem('nr_pending_neighborhood');
+            return config.neighborhoodMap[pending];
+        }
+
+        return '';
 
     };
 
     const setNeighborhoodInURL = name => {
 
-        // Keep the browser URL synchronized with the current neighborhood selection
-        const url = new URL(window.location);
+        // Update the browser's address bar to show the neighborhood in the path, e.g.
+        //   /neighborhood-reports/asthma_and_the_environment/east_new_york
+        // Uses history.replaceState so the page does not reload — this is purely cosmetic,
+        // making the URL shareable and bookmarkable without triggering a new server request.
+        const config = window.NR_TOPIC_SPA_CONFIG;
+        const slug = Object.keys(config.neighborhoodMap).find(k => config.neighborhoodMap[k] === name);
 
-        url.searchParams.set('neighborhood', name);
-        history.replaceState(null, '', url);
+        if (!slug) {
+            return;
+        }
+
+        // Find the topic slug in the current path and replace everything after it
+        // with the neighborhood slug, preserving any site path prefix (e.g. /dev-prod/)
+        const pathParts = window.location.pathname.replace(/\/$/, '').split('/').filter(Boolean);
+        const topicIdx = pathParts.findIndex(p => p === config.topicSlug);
+
+        if (topicIdx === -1) {
+            return;
+        }
+
+        const newPath = '/' + pathParts.slice(0, topicIdx + 1).join('/') + '/' + slug;
+        history.replaceState(null, '', newPath);
 
     };
 
     const updateTopicLinks = neighborhoodName => {
 
-        // Ensure in-page topic links preserve the active neighborhood context
+        // When the user clicks a topic tab (e.g. switching from Asthma to Housing),
+        // we need the new topic page to open with the same neighborhood pre-selected.
+        // Rather than embedding the neighborhood in the link href (which would cause a
+        // 404 in dev and requires IIS rewrite in production), we store the slug in
+        // sessionStorage just before the navigation fires. The new topic SPA reads it
+        // on load via getNeighborhoodFromURL above.
+        const config = window.NR_TOPIC_SPA_CONFIG;
+        const slug = Object.keys(config.neighborhoodMap).find(k => config.neighborhoodMap[k] === neighborhoodName);
         const links = document.querySelectorAll('.nr-topic-link');
 
         links.forEach(a => {
 
-            const url = new URL(a.href, window.location.origin);
-            url.searchParams.set('neighborhood', neighborhoodName);
-            a.href = url.toString();
+            a.onclick = () => {
+                if (slug) {
+                    sessionStorage.setItem('nr_pending_neighborhood', slug);
+                }
+            };
 
         });
 

--- a/assets/js/nr-topic-spa.js
+++ b/assets/js/nr-topic-spa.js
@@ -1,881 +1,1062 @@
-// Topic-centric Neighborhood Reports viewer.
+// Topic-centric Neighborhood Reports viewer
 //
 // Expects window.NR_TOPIC_SPA_CONFIG set by the Hugo layout with:
-//   - sections: array of { id, containerId, reportUrl } objects, one per report_topic.
-//   - geojsonUrl: URL to UHF42 GeoJSON for the Leaflet selector map.
-//   - vizUrl: EHDP-data viz JSON URL for map/chart rendering.
-//   - dataRepo: base URL for EHDP-data (used to build geography TopoJSON URLs).
-//   - dataBranch: branch name for EHDP-data.
+//   - sections: array of { id, containerId, reportUrl } objects, one per report_topic
+//   - geojsonUrl: URL to UHF42 GeoJSON for the Leaflet selector map
+//   - vizUrl: EHDP-data viz JSON URL for map/chart rendering
+//   - dataRepo: base URL for EHDP-data (used to build geography TopoJSON URLs)
+//   - dataBranch: branch name for EHDP-data
 //
 // Features:
-//   - Interactive Leaflet map as sole neighborhood selector.
-//   - Accordion expand/collapse per indicator row with detail panel.
-//   - Vega choropleth map + bar chart rendered on first accordion expand.
-//   - Borough/city comparison logic with judgment styling.
-//   - Demographics sidebar populated from uhflist.js.
-//   - Neighborhood persistence via URL query parameter.
-;(function () {
-  var config = window.NR_TOPIC_SPA_CONFIG;
-  if (!config || !config.sections || !config.sections.length) {
-    return;
-  }
+//   - Interactive Leaflet map as sole neighborhood selector
+//   - Accordion expand/collapse per indicator row with detail panel
+//   - Vega choropleth map + bar chart rendered on first accordion expand
+//   - Borough/city comparison logic with judgment styling
+//   - Demographics sidebar populated from uhflist.js
+//   - Neighborhood persistence via URL query parameter
 
-  var mapContainer = document.getElementById('nr-map');
-  if (!mapContainer) {
-    return;
-  }
+// Named init function used in place of an IIFE so early returns remain available
+const init = () => {
 
-  // Per-section data store: sectionId -> { neighborhoodName -> rows[] }
-  var sectionData = {};
+    const config = window.NR_TOPIC_SPA_CONFIG;
 
-  // Arquero table for the viz dataset (all indicators, all neighborhoods).
-  var vizTable = null;
-
-  // Track which accordion panels have already had their chart rendered.
-  var renderedPanels = {};
-
-  // Track loading: sections + viz = total fetches needed before first render.
-  var totalFetches = config.sections.length + (config.vizUrl ? 1 : 0);
-  var fetchesComplete = 0;
-
-  // Current neighborhood and geocode, updated on switch.
-  var currentNeighborhood = '';
-  var currentGeocode = null;
-
-  // Leaflet map and GeoJSON layer references.
-  var leafletMap = null;
-  var uhfLayer = null;
-  var dataReady = false;
-  var mapReady = false;
-
-  // --- URL param persistence ---
-
-  function getNeighborhoodFromURL() {
-    var params = new URLSearchParams(window.location.search);
-    return params.get('neighborhood') || '';
-  }
-
-  function setNeighborhoodInURL(name) {
-    var url = new URL(window.location);
-    url.searchParams.set('neighborhood', name);
-    history.replaceState(null, '', url);
-  }
-
-  function updateTopicLinks(neighborhoodName) {
-    var links = document.querySelectorAll('.nr-topic-link');
-    links.forEach(function (a) {
-      var url = new URL(a.href, window.location.origin);
-      url.searchParams.set('neighborhood', neighborhoodName);
-      a.href = url.toString();
-    });
-  }
-
-  // --- helpers ---
-
-  function getTertileLabel(rank, rankReverse) {
-    var r = String(rank);
-    var reverse = rankReverse === true || rankReverse === 'true';
-    if (r === '1') {
-      return reverse ? 'Lower' : 'Higher';
-    }
-    if (r === '2') {
-      return '';
-    }
-    if (r === '3') {
-      return reverse ? 'Higher' : 'Lower';
-    }
-    return '';
-  }
-
-  // Returns the production CSS pill class: worse, better, or middle.
-  function getTertilePillClass(rank, rankReverse) {
-    var r = String(rank);
-    var reverse = rankReverse === true || rankReverse === 'true';
-    if (r === '1') return reverse ? 'better' : 'worse';
-    if (r === '3') return reverse ? 'worse' : 'better';
-    if (r === '2') return 'middle';
-    return '';
-  }
-
-  // Returns the -sm variant class for inline comparison emojis.
-  function getTertileSmClass(rank, rankReverse) {
-    var r = String(rank);
-    var reverse = rankReverse === true || rankReverse === 'true';
-    if (r === '1') return reverse ? 'better-sm' : 'worse-sm';
-    if (r === '3') return reverse ? 'worse-sm' : 'better-sm';
-    if (r === '2') return 'middle-sm';
-    return '';
-  }
-
-  function getTertileInlineLabel(rank, rankReverse) {
-    var r = String(rank);
-    var reverse = rankReverse === true || rankReverse === 'true';
-    if (r === '1') {
-      return reverse
-        ? '<span class="comp-good">Lower</span> than most neighborhoods'
-        : '<span class="comp-bad">Higher</span> than most neighborhoods';
-    }
-    if (r === '2') {
-      return '<span class="comp-null">In the middle of</span> neighborhoods';
-    }
-    if (r === '3') {
-      return reverse
-        ? '<span class="comp-bad">Higher</span> than most neighborhoods'
-        : '<span class="comp-good">Lower</span> than most neighborhoods';
-    }
-    return '';
-  }
-
-  function getComparison(neighVal, refVal, rankReverse) {
-    var n = Number(neighVal);
-    var r = Number(refVal);
-    var reverse = rankReverse === true || rankReverse === 'true';
-    if (isNaN(n) || isNaN(r)) {
-      return { text: '', cssClass: '' };
-    }
-    var comp;
-    var cls;
-    if (n > r) {
-      comp = 'Higher than';
-      cls = reverse ? 'comp-good' : 'comp-bad';
-    } else if (n < r) {
-      comp = 'Lower than';
-      cls = reverse ? 'comp-bad' : 'comp-good';
-    } else {
-      comp = 'Equal to';
-      cls = 'comp-null';
-    }
-    return { text: comp, cssClass: cls };
-  }
-
-  var accordionCounter = 0;
-  function nextAccordionId() {
-    return 'nr-acc-' + (++accordionCounter);
-  }
-
-  // Safe for double-quoted HTML attributes (e.g. data-legend-label).
-  function escapeAttr(value) {
-    if (value == null) return '';
-    return String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-  }
-
-  // uhflist.js has one known typo: "Crotona -Tremont" (missing space after dash).
-  // EHDP-data report JSONs use "Crotona - Tremont". This map corrects it so
-  // lookups against report data and sidebar demographics stay aligned.
-  var nameCorrections = {
-    'Crotona -Tremont': 'Crotona - Tremont'
-  };
-
-  function getUhfIdForDisplayName(displayName) {
-    if (!displayName || typeof neighborhoods === 'undefined') return null;
-    var entry = neighborhoods.find(function (n) {
-      var corrected = nameCorrections[n.UHF_name] || n.UHF_name;
-      return corrected === displayName;
-    });
-    return entry ? entry.UHF_id : null;
-  }
-
-  // --- demographics sidebar ---
-
-  function clearDemographicsSidebar() {
-    var metricIds = [
-      'nr-pop',
-      'nr-old',
-      'nr-young',
-      'nr-pov',
-      'nr-grad',
-      'nr-eng',
-      'nr-own',
-      'nr-rent'
-    ];
-    metricIds.forEach(function (id) {
-      var node = document.getElementById(id);
-      if (node) node.innerHTML = '';
-    });
-    var zipList = document.getElementById('nr-zip-list');
-    if (zipList) zipList.textContent = '';
-    var demoPanel = document.getElementById('nr-demographics');
-    if (demoPanel) demoPanel.style.display = 'none';
-    var zipPanel = document.getElementById('nr-zip-codes');
-    if (zipPanel) zipPanel.style.display = 'none';
-  }
-
-  function renderDemographics(geocode) {
-    if (typeof neighborhoods === 'undefined' || geocode == null || geocode === '') {
-      clearDemographicsSidebar();
-      return;
+    if (!config || !config.sections || !config.sections.length) {
+        return;
     }
 
-    var here = neighborhoods.filter(function (n) { return n.UHF_id == geocode; });
-    if (!here.length) {
-      clearDemographicsSidebar();
-      return;
+    if (!document.getElementById('nr-map')) {
+        return;
     }
 
-    var d = here[0];
+    // Per-section data store: sectionId -> { neighborhoodName -> rows[] }
+    const sectionData = {};
 
-    var el = function (id) { return document.getElementById(id); };
+    // Arquero table for the viz dataset (all indicators, all neighborhoods)
+    let vizTable = null;
 
-    if (el('nr-pop'))   el('nr-pop').innerHTML   = Number(d.TotalPopulation).toLocaleString();
-    if (el('nr-old'))   el('nr-old').innerHTML   = Number(d.PercentOver65).toFixed(1) + '%';
-    if (el('nr-young')) el('nr-young').innerHTML = Number(d.PercentUnder18).toFixed(1) + '%';
-    if (el('nr-pov'))   el('nr-pov').innerHTML   = Number(d.PovertyPercent).toFixed(1) + '%';
-    if (el('nr-grad'))  el('nr-grad').innerHTML  = Number(d.PercentGraduatedHighSchool).toFixed(1) + '%';
-    if (el('nr-eng'))   el('nr-eng').innerHTML   = Number(d.PercentLimitedEnglish).toFixed(1) + '%';
-    if (el('nr-own'))   el('nr-own').innerHTML   = Number(d.PercentOwnerOccupied).toFixed(1) + '%';
-    if (el('nr-rent'))  el('nr-rent').innerHTML  = Number(d.PercentRentBurdened).toFixed(1) + '%';
+    // Track which accordion panels have already had their chart rendered
+    let renderedPanels = {};
 
-    var demoPanel = document.getElementById('nr-demographics');
-    if (demoPanel) demoPanel.style.display = '';
+    // Track loading: sections + viz = total fetches needed before first render
+    const totalFetches = config.sections.length + (config.vizUrl ? 1 : 0);
+    let fetchesComplete = 0;
 
-    if (el('nr-zip-list')) {
-      el('nr-zip-list').textContent = d.Zipcodes || '';
-    }
-    var zipPanel = document.getElementById('nr-zip-codes');
-    if (zipPanel && d.Zipcodes) zipPanel.style.display = '';
-  }
+    // Current neighborhood and geocode, updated on switch
+    let currentNeighborhood = '';
+    let currentGeocode = null;
 
-  // --- rendering ---
+    // Leaflet map and GeoJSON layer references
+    let leafletMap = null;
+    let uhfLayer = null;
+    let dataReady = false;
+    let mapReady = false;
 
-  function buildIndicatorCard(row, sectionId, neighborhoodName, accordionParentId) {
-    var accId = nextAccordionId();
-    var headingId = accId + '-h';
-    var collapseId = accId + '-c';
+    // --- URL param persistence ---
 
-    var value =
-      row.data_value_geo_entity !== null && row.data_value_geo_entity !== undefined
-        ? row.data_value_geo_entity
-        : '–';
+    const getNeighborhoodFromURL = () => {
 
-    var unitParts = [];
-    if (row.measurement_type) unitParts.push(row.measurement_type);
-    if (row.units) unitParts.push(row.units);
-    var units = unitParts.join(' ').trim();
+        const params = new URLSearchParams(window.location.search);
 
-    // Tertile pill for the header row (production uses .worse/.better/.middle classes)
-    var pillLabel = getTertileLabel(row.data_value_rank, row.rankReverse);
-    var pillClass = getTertilePillClass(row.data_value_rank, row.rankReverse);
-    var pillHTML = '';
-    if (pillLabel && pillClass) {
-      pillHTML = '<span class="' + pillClass + '">' + pillLabel + '</span>';
-    }
+        return params.get('neighborhood') || '';
 
-    var headerHTML =
-      '<div class="card-header border-top" id="' + headingId + '">' +
-        '<h2 class="mb-0">' +
-        '<button class="btn btn-block btn-sm text-left" type="button" ' +
-          'data-toggle="collapse" data-target="#' + collapseId + '" ' +
-          'aria-expanded="false" aria-controls="' + collapseId + '">' +
-          '<div class="row no-gutters d-print-none" style="width:100%">' +
-            '<div class="col-7">' +
-              '<span class="font-weight-bold fs-md">' + (row.indicator_short_name || '') + '</span><br>' +
-              '<span class="fs-sm font-weight-normal">' + (row.indicator_long_name || '') + '</span>' +
-            '</div>' +
-            '<div class="col-3 pl-1">' +
-              '<span class="font-weight-bold fs-lg">' + value + '</span><br>' +
-              '<span class="fs-xs font-weight-normal">' + units + '</span>' +
-            '</div>' +
-            '<div class="col-2">' +
-              '<div class="float-right mt-1">' + pillHTML + '</div>' +
-            '</div>' +
-          '</div>' +
-        '</button>' +
-        '</h2>' +
-      '</div>';
-
-    var hasRank = row.data_value_rank != null;
-
-    var boroComp = getComparison(
-      row.unmodified_data_value_geo_entity,
-      row.data_value_boro,
-      row.rankReverse
-    );
-    var cityComp = getComparison(
-      row.unmodified_data_value_geo_entity,
-      row.data_value_nyc,
-      row.rankReverse
-    );
-
-    var boroName = row.borough_name || 'Borough';
-    var boroVal = row.data_value_boro != null ? row.data_value_boro : '';
-    var cityVal = row.data_value_nyc != null ? row.data_value_nyc : '';
-    var unitSuffix = '';
-    if (row.measurement_type && row.measurement_type.toLowerCase().indexOf('ercent') !== -1) {
-      unitSuffix = '%';
-    } else if (row.units) {
-      unitSuffix = ' ' + row.units;
-    }
-
-    var tertileInlineHTML = getTertileInlineLabel(row.data_value_rank, row.rankReverse);
-
-    var comparisonsHTML = '';
-    var hideClass = hasRank ? '' : ' d-none';
-    comparisonsHTML =
-      '<div class="col-md-5 h-100 p-1' + hideClass + '">' +
-        '<p class="fs-rg">' + (row.indicator_short_name || '') + ' in <strong>' + neighborhoodName + '</strong>:</p>' +
-        '<div class="fs-md">' +
-          (tertileInlineHTML
-            ? '<p>' + tertileInlineHTML + '</p>'
-            : '') +
-          (boroComp.text
-            ? '<p><span class="' + boroComp.cssClass + '">' + boroComp.text + '</span> the <strong>' + boroName + ' average</strong>' +
-              '<br><span class="fs-sm pl-3">(' + boroVal + unitSuffix + ')</span></p>'
-            : '') +
-          (cityComp.text
-            ? '<p><span class="' + cityComp.cssClass + '">' + cityComp.text + '</span> the <strong>Citywide average</strong>' +
-              '<br><span class="fs-sm pl-3">(' + cityVal + unitSuffix + ')</span></p>'
-            : '') +
-        '</div>' +
-      '</div>';
-
-    var detailHTML =
-      '<div id="' + collapseId + '" class="collapse border-bottom" ' +
-        'aria-labelledby="' + headingId + '" ' +
-        'data-parent="#' + accordionParentId + '" ' +
-        'data-indicator-name="' + (row.indicator_data_name || '') + '" ' +
-        'data-legend-label="' + escapeAttr(units) + '" ' +
-        'data-geocode="' + (row.geo_join_id || row.geo_entity_id || '') + '">' +
-        '<div class="card-body card-body-no-top">' +
-          '<div class="row no-gutters fs-sm">' +
-            '<div class="col-12">' +
-              '<p class="fs-md mt-1 mb-2">' + (row.indicator_description || '') + '</p>' +
-            '</div>' +
-            '<div class="col-md-7 border-right h-100">' +
-              '<div class="nr-map-container" id="map-' + accId + '" style="width:100%;min-height:350px;">' +
-                '<p class="text-muted small">Chart loads when expanded...</p>' +
-              '</div>' +
-            '</div>' +
-            comparisonsHTML +
-          '</div>' +
-          '<div class="row no-gutters">' +
-            '<div class="col-7">' +
-              '<p class="fs-xs"><strong>Source:</strong> ' + (row.data_source_list || '') + '</p>' +
-            '</div>' +
-          '</div>' +
-        '</div>' +
-      '</div>';
-
-    return headerHTML + detailHTML;
-  }
-
-  function renderSection(section, neighborhoodName) {
-    var container = document.getElementById(section.containerId);
-    if (!container) return;
-
-    var byNeighborhood = sectionData[section.id] || {};
-    var rows = byNeighborhood[neighborhoodName] || [];
-
-    container.innerHTML = '';
-
-    if (!rows.length) {
-      container.innerHTML =
-        '<p class="text-muted px-2 pb-2 mb-0">No data available for this neighborhood.</p>';
-      return;
-    }
-
-    var accordionParentId = 'nr-accordion-' + section.id;
-
-    rows.forEach(function (row) {
-      var card = document.createElement('div');
-      card.innerHTML = buildIndicatorCard(row, section.id, neighborhoodName, accordionParentId);
-      container.appendChild(card);
-    });
-  }
-
-  function renderAll(neighborhoodName, mapGeocode) {
-    currentNeighborhood = neighborhoodName;
-    renderedPanels = {};
-    accordionCounter = 0;
-
-    currentGeocode = null;
-    for (var sid in sectionData) {
-      var nb = sectionData[sid][neighborhoodName];
-      if (nb && nb.length) {
-        var row0 = nb[0];
-        var gj =
-          row0.geo_join_id != null && row0.geo_join_id !== ''
-            ? row0.geo_join_id
-            : row0.geo_entity_id;
-        if (gj != null && gj !== '') {
-          currentGeocode = gj;
-          break;
-        }
-      }
-    }
-
-    if (
-      (currentGeocode == null || currentGeocode === '') &&
-      mapGeocode != null &&
-      mapGeocode !== ''
-    ) {
-      currentGeocode = mapGeocode;
-    }
-
-    if (currentGeocode == null || currentGeocode === '') {
-      currentGeocode = getUhfIdForDisplayName(neighborhoodName);
-    }
-
-    config.sections.forEach(function (section) {
-      renderSection(section, neighborhoodName);
-    });
-
-    // Show the report header and fill in the neighborhood name.
-    var reportHeader = document.getElementById('nr-report-header');
-    var headerNeighborhood = document.getElementById('nr-header-neighborhood');
-    if (reportHeader) {
-      reportHeader.style.display = '';
-    }
-    if (headerNeighborhood) {
-      headerNeighborhood.textContent = neighborhoodName;
-    }
-
-    // Mobile title
-    var mobileTitle = document.getElementById('nr-mobile-title');
-    var mobileNeighborhood = document.getElementById('nr-mobile-neighborhood');
-    if (mobileTitle) mobileTitle.style.display = '';
-    if (mobileNeighborhood) mobileNeighborhood.textContent = neighborhoodName;
-
-    renderDemographics(currentGeocode);
-
-    setNeighborhoodInURL(neighborhoodName);
-    updateTopicLinks(neighborhoodName);
-  }
-
-  // --- CSV download ---
-
-  function downloadCSV() {
-    if (!vizTable || !currentNeighborhood) return;
-
-    var csv = vizTable
-      .select(aq.not('report_id', 'indicator_id', 'indicator_data_name', 'start_date', 'end_date'))
-      .filter(aq.escape(function (d) { return d.neighborhood === currentNeighborhood; }))
-      .toCSV();
-
-    var filename = 'NYC EH Data Portal - Neighborhood Report - ' +
-      (config.reportName || 'Report') + ' - ' + currentNeighborhood + '.csv';
-
-    var blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    var url = URL.createObjectURL(blob);
-    var link = document.createElement('a');
-    link.href = url;
-    link.download = filename;
-    link.click();
-    URL.revokeObjectURL(url);
-  }
-
-  window.nrDownloadCSV = downloadCSV;
-
-  // --- Vega map + bar chart ---
-
-  function renderNRMap(data, destination, legendLabel, geocode) {
-    var boroTopoUrl = config.dataRepo + config.dataBranch + '/geography/borough.topo.json';
-    var uhfTopoUrl = config.dataRepo + config.dataBranch + '/geography/UHF42.topo.json';
-
-    var spec = {
-      "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-      "data": {
-        "values": data,
-        "format": { "parse": { "Value": "number" } }
-      },
-      "config": {
-        "concat": { "spacing": 20 },
-        "view": { "stroke": "transparent" },
-        "axisY": { "domain": false, "ticks": false, "labelBaseline": "bottom" },
-        "legend": { "disable": true },
-        "scale": { "invalid": { "color": { "value": "#808080" } } }
-      },
-      "projection": { "type": "mercator" },
-      "vconcat": [
-        {
-          "layer": [
-            {
-              "height": 300,
-              "width": "container",
-              "data": {
-                "url": boroTopoUrl,
-                "format": { "type": "topojson", "feature": "collection" }
-              },
-              "mark": { "type": "geoshape", "stroke": "#fafafa", "fill": "#C5C5C5", "strokeWidth": 0.5 }
-            },
-            {
-              "height": 300,
-              "width": "container",
-              "data": {
-                "url": uhfTopoUrl,
-                "format": { "type": "topojson", "feature": "collection" }
-              },
-              "mark": { "type": "geoshape", "stroke": "#a2a2a2", "fill": "#e7e7e7", "strokeWidth": 0.5 }
-            },
-            {
-              "height": 300,
-              "width": "container",
-              "mark": { "type": "geoshape", "invalid": null },
-              "transform": [
-                {
-                  "lookup": "geo_join_id",
-                  "from": {
-                    "data": {
-                      "url": uhfTopoUrl,
-                      "format": { "type": "topojson", "feature": "collection" }
-                    },
-                    "key": "properties.GEOCODE"
-                  },
-                  "as": "geo"
-                }
-              ],
-              "encoding": {
-                "shape": { "field": "geo", "type": "geojson" },
-                "color": {
-                  "field": "unmodified_data_value_geo_entity",
-                  "type": "quantitative",
-                  "scale": { "scheme": { "name": "viridis", "extent": [1, 0] } },
-                  "legend": {
-                    "direction": "horizontal",
-                    "orient": "top-left",
-                    "title": legendLabel,
-                    "fontWeight": "normal",
-                    "tickCount": 3,
-                    "offset": -25,
-                    "gradientLength": 200
-                  }
-                },
-                "order": {
-                  "condition": { "test": "datum.geo_join_id == " + geocode, "value": 1 },
-                  "value": 0
-                },
-                "stroke": {
-                  "condition": { "test": "datum.geo_join_id == " + geocode, "value": "cyan" },
-                  "value": "#2d2d2d"
-                },
-                "strokeWidth": {
-                  "condition": { "test": "datum.geo_join_id == " + geocode, "value": 2.5 },
-                  "value": 0.5
-                },
-                "tooltip": [
-                  { "field": "neighborhood", "title": "Neighborhood", "type": "nominal" },
-                  { "field": "unmodified_data_value_geo_entity", "title": legendLabel, "type": "quantitative" }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "height": 80,
-          "width": "container",
-          "mark": { "type": "bar", "tooltip": true, "stroke": "#161616" },
-          "encoding": {
-            "y": {
-              "field": "unmodified_data_value_geo_entity",
-              "type": "quantitative",
-              "title": null,
-              "axis": { "labelAngle": 0, "labelFontSize": 11, "tickCount": 3 }
-            },
-            "x": { "field": "geo_join_id", "sort": "y", "axis": null },
-            "color": {
-              "field": "unmodified_data_value_geo_entity",
-              "type": "quantitative",
-              "scale": { "scheme": { "name": "viridis", "extent": [1, 0] } },
-              "legend": false
-            },
-            "order": {
-              "condition": { "test": "datum.geo_join_id == " + geocode, "value": 1 },
-              "value": 0
-            },
-            "stroke": {
-              "condition": { "test": "datum.geo_join_id == " + geocode, "value": "cyan" },
-              "value": "#2d2d2d"
-            },
-            "strokeWidth": {
-              "condition": { "test": "datum.geo_join_id == " + geocode, "value": 2.5 },
-              "value": 0
-            },
-            "tooltip": [
-              { "field": "neighborhood", "title": "Neighborhood", "type": "nominal" },
-              { "field": "unmodified_data_value_geo_entity", "title": legendLabel, "type": "quantitative" }
-            ]
-          }
-        }
-      ]
     };
 
-    vegaEmbed(destination, spec, { actions: true });
-  }
+    const setNeighborhoodInURL = name => {
 
-  function onAccordionExpand(event) {
-    var panel = event.target;
-    var panelId = panel.id;
-    if (renderedPanels[panelId]) return;
+        // Keep the browser URL synchronized with the current neighborhood selection
+        const url = new URL(window.location);
 
-    var indicatorName = panel.getAttribute('data-indicator-name');
-    var geocode = panel.getAttribute('data-geocode') || currentGeocode;
-    var mapEl = panel.querySelector('.nr-map-container');
-    if (!indicatorName || !mapEl || !vizTable) return;
+        url.searchParams.set('neighborhood', name);
+        history.replaceState(null, '', url);
 
-    try {
-      var summaryData = vizTable
-        .filter(aq.escape(function (d) { return d.indicator_data_name === indicatorName; }))
-        .select('geo_join_id', 'neighborhood', 'unmodified_data_value_geo_entity', 'end_date')
-        .dedupe()
-        .groupby('neighborhood')
-        .orderby('neighborhood', aq.desc('end_date'))
-        .slice(0, 1)
-        .ungroup()
-        .derive({ unmodified_data_value_geo_entity: function (d) { return op.parse_float(d.unmodified_data_value_geo_entity); } })
-        .orderby('unmodified_data_value_geo_entity')
-        .select(aq.not('end_date'))
-        .objects();
+    };
 
-      if (summaryData.length) {
-        mapEl.innerHTML = '';
-        var legendLabel = panel.getAttribute('data-legend-label');
-        if (!legendLabel || !String(legendLabel).trim()) {
-          legendLabel = 'Value';
+    const updateTopicLinks = neighborhoodName => {
+
+        // Ensure in-page topic links preserve the active neighborhood context
+        const links = document.querySelectorAll('.nr-topic-link');
+
+        links.forEach(a => {
+
+            const url = new URL(a.href, window.location.origin);
+            url.searchParams.set('neighborhood', neighborhoodName);
+            a.href = url.toString();
+
+        });
+
+    };
+
+    // --- helpers ---
+
+    const getTertileLabel = (rank, rankReverse) => {
+
+        // Normalize rank values that may arrive as numbers or strings
+        const r = String(rank);
+        // rankReverse indicates indicators where lower values are directionally better
+        const reverse = rankReverse === true || rankReverse === 'true';
+
+        if (r === '1') {
+            return reverse ? 'Lower' : 'Higher';
         }
-        renderNRMap(summaryData, '#' + mapEl.id, legendLabel, geocode);
-      } else {
-        mapEl.innerHTML = '<p class="text-muted small">No chart data available.</p>';
-      }
-    } catch (e) {
-      console.error('Error rendering map for ' + indicatorName + ':', e);
-      mapEl.innerHTML = '<p class="text-muted small">Unable to render chart.</p>';
-    }
 
-    renderedPanels[panelId] = true;
-  }
+        if (r === '2') {
+            return '';
+        }
 
-  // --- Leaflet neighborhood selector map ---
+        if (r === '3') {
+            return reverse ? 'Higher' : 'Lower';
+        }
 
-  var defaultStyle = {
-    weight: 1.5,
-    opacity: 1,
-    color: 'black',
-    dashArray: '1',
-    fillOpacity: 0.05,
-    fillColor: '#008939'
-  };
+        return '';
 
-  var highlightStyle = {
-    weight: 3,
-    color: '#008939',
-    dashArray: '3',
-    fillOpacity: 0.5
-  };
+    };
 
-  function styleFeature() {
-    return defaultStyle;
-  }
+    // Returns the production CSS pill class: worse, better, or middle
+    const getTertilePillClass = (rank, rankReverse) => {
 
-  function highlightFeature(e) {
-    var layer = e.target;
-    layer.setStyle({ weight: 5, color: '#444', dashArray: '' });
-    layer.bringToFront();
-  }
+        const r = String(rank);
+        const reverse = rankReverse === true || rankReverse === 'true';
 
-  function resetHighlight(e) {
-    var layer = e.target;
-    var geocode = layer.feature.properties.GEOCODE;
-    if (geocode == currentGeocode) return;
-    layer.setStyle({ weight: 1.5, color: 'black', dashArray: '1' });
-  }
+        if (r === '1') return reverse ? 'better' : 'worse';
+        if (r === '3') return reverse ? 'worse' : 'better';
+        if (r === '2') return 'middle';
 
-  function selectLayer(layer, zoom) {
-    if (uhfLayer) uhfLayer.resetStyle();
-    layer.setStyle(highlightStyle);
-    layer.bringToFront();
-    if (zoom && leafletMap) {
-      leafletMap.flyToBounds(layer.getBounds(), { duration: 0.5 });
-    }
-  }
+        return '';
 
-  function geocodeToName(geocode) {
-    if (typeof neighborhoods === 'undefined') return null;
-    var match = neighborhoods.find(function (n) { return n.UHF_id == geocode; });
-    if (!match) return null;
-    var name = match.UHF_name;
-    return nameCorrections[name] || name;
-  }
+    };
 
-  function findLayerByGeocode(geocode) {
-    if (!uhfLayer) return null;
-    var match = null;
-    uhfLayer.eachLayer(function (layer) {
-      if (layer.feature.properties.GEOCODE == geocode) {
-        match = layer;
-      }
-    });
-    return match;
-  }
+    // Returns the -sm variant class for inline comparison indicators
+    const getTertileSmClass = (rank, rankReverse) => {
 
-  function findLayerByName(name) {
-    if (typeof neighborhoods === 'undefined' || !uhfLayer) return null;
-    var entry = neighborhoods.find(function (n) {
-      var corrected = nameCorrections[n.UHF_name] || n.UHF_name;
-      return corrected === name;
-    });
-    if (!entry) return null;
-    return findLayerByGeocode(entry.UHF_id);
-  }
+        const r = String(rank);
+        const reverse = rankReverse === true || rankReverse === 'true';
 
-  function onMapClick(e) {
-    var layer = e.target;
-    var geocode = layer.feature.properties.GEOCODE;
-    var name = geocodeToName(geocode) || layer.feature.properties.GEONAME;
-    selectLayer(layer, true);
-    if (dataReady) {
-      renderAll(name, geocode);
-    }
-  }
+        if (r === '1') return reverse ? 'better-sm' : 'worse-sm';
+        if (r === '3') return reverse ? 'worse-sm' : 'better-sm';
+        if (r === '2') return 'middle-sm';
 
-  function onEachFeature(feature, layer) {
-    layer.bindTooltip(feature.properties.GEONAME, {
-      permanent: false,
-      opacity: 0.9,
-      className: 'fs-md'
-    });
-    layer.on({
-      mouseover: highlightFeature,
-      mouseout: resetHighlight,
-      click: onMapClick
-    });
-  }
+        return '';
 
-  function initLeafletMap() {
-    leafletMap = L.map('nr-map', { zoomControl: false }).setView([40.7128, -74.006], 10);
+    };
 
-    L.tileLayer(
-      'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
-      {
-        maxZoom: 15,
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
-      }
-    ).addTo(leafletMap);
+    const getTertileInlineLabel = (rank, rankReverse) => {
 
-    L.control.scale({ metric: false, position: 'bottomleft' }).addTo(leafletMap);
+        const r = String(rank);
+        const reverse = rankReverse === true || rankReverse === 'true';
 
-    fetch(config.geojsonUrl)
-      .then(function (response) { return response.json(); })
-      .then(function (data) {
-        uhfLayer = L.geoJSON(data, {
-          style: styleFeature,
-          onEachFeature: onEachFeature,
-          filter: function (feature) { return feature.properties.GEOCODE != 0; }
-        }).addTo(leafletMap);
+        if (r === '1') {
+            return reverse
+                ? '<span class="comp-good">Lower</span> than most neighborhoods'
+                : '<span class="comp-bad">Higher</span> than most neighborhoods';
+        }
 
-        mapReady = true;
-        tryInitialRender();
-      })
-      .catch(function (err) {
-        console.error('Error loading UHF42 GeoJSON:', err);
-        mapReady = true;
-        tryInitialRender();
-      });
-  }
+        if (r === '2') {
+            return '<span class="comp-null">In the middle of</span> neighborhoods';
+        }
 
-  // --- data loading ---
+        if (r === '3') {
+            return reverse
+                ? '<span class="comp-bad">Higher</span> than most neighborhoods'
+                : '<span class="comp-good">Lower</span> than most neighborhoods';
+        }
 
-  function tryInitialRender() {
-    if (!dataReady || !mapReady) return;
+        return '';
 
-    var fromURL = getNeighborhoodFromURL();
-    if (fromURL) {
-      var layer = findLayerByName(fromURL);
-      if (layer) {
+    };
+
+    const getComparison = (neighVal, refVal, rankReverse) => {
+
+        const n = Number(neighVal);
+        const r = Number(refVal);
+        const reverse = rankReverse === true || rankReverse === 'true';
+
+        if (isNaN(n) || isNaN(r)) {
+            return { text: '', cssClass: '' };
+        }
+
+        let comp;
+        let cls;
+
+        if (n > r) {
+            comp = 'Higher than';
+            cls = reverse ? 'comp-good' : 'comp-bad';
+        } else if (n < r) {
+            comp = 'Lower than';
+            cls = reverse ? 'comp-bad' : 'comp-good';
+        } else {
+            comp = 'Equal to';
+            cls = 'comp-null';
+        }
+
+        return { text: comp, cssClass: cls };
+
+    };
+
+    let accordionCounter = 0;
+
+    const nextAccordionId = () => 'nr-acc-' + (++accordionCounter);
+
+    // Safe for double-quoted HTML attributes (e.g. data-legend-label)
+    const escapeAttr = value => {
+
+        if (value == null) return '';
+        return String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+
+    };
+
+    // uhflist.js has one known typo: "Crotona -Tremont" (missing space after dash)
+    // EHDP-data report JSONs use "Crotona - Tremont". This map corrects it so
+    // lookups against report data and sidebar demographics stay aligned
+    const nameCorrections = {
+        'Crotona -Tremont': 'Crotona - Tremont'
+    };
+
+    const getUhfIdForDisplayName = displayName => {
+
+        if (!displayName || typeof neighborhoods === 'undefined') return null;
+
+        const entry = neighborhoods.find(n => {
+            const corrected = nameCorrections[n.UHF_name] || n.UHF_name;
+            return corrected === displayName;
+        });
+
+        return entry ? entry.UHF_id : null;
+
+    };
+
+    // --- demographics sidebar ---
+
+    const clearDemographicsSidebar = () => {
+
+        const metricIds = [
+            'nr-pop',
+            'nr-old',
+            'nr-young',
+            'nr-pov',
+            'nr-grad',
+            'nr-eng',
+            'nr-own',
+            'nr-rent'
+        ];
+
+        metricIds.forEach(id => {
+            const node = document.getElementById(id);
+            if (node) node.innerHTML = '';
+        });
+
+        const zipList = document.getElementById('nr-zip-list');
+        if (zipList) zipList.textContent = '';
+
+        const demoPanel = document.getElementById('nr-demographics');
+        if (demoPanel) demoPanel.style.display = 'none';
+
+        const zipPanel = document.getElementById('nr-zip-codes');
+        if (zipPanel) zipPanel.style.display = 'none';
+
+    };
+
+    const renderDemographics = geocode => {
+
+        if (typeof neighborhoods === 'undefined' || geocode == null || geocode === '') {
+            clearDemographicsSidebar();
+            return;
+        }
+
+        const here = neighborhoods.filter(n => n.UHF_id == geocode);
+
+        if (!here.length) {
+            clearDemographicsSidebar();
+            return;
+        }
+
+        const d = here[0];
+        const el = id => document.getElementById(id);
+
+        if (el('nr-pop'))   el('nr-pop').innerHTML   = Number(d.TotalPopulation).toLocaleString();
+        if (el('nr-old'))   el('nr-old').innerHTML   = Number(d.PercentOver65).toFixed(1) + '%';
+        if (el('nr-young')) el('nr-young').innerHTML = Number(d.PercentUnder18).toFixed(1) + '%';
+        if (el('nr-pov'))   el('nr-pov').innerHTML   = Number(d.PovertyPercent).toFixed(1) + '%';
+        if (el('nr-grad'))  el('nr-grad').innerHTML  = Number(d.PercentGraduatedHighSchool).toFixed(1) + '%';
+        if (el('nr-eng'))   el('nr-eng').innerHTML   = Number(d.PercentLimitedEnglish).toFixed(1) + '%';
+        if (el('nr-own'))   el('nr-own').innerHTML   = Number(d.PercentOwnerOccupied).toFixed(1) + '%';
+        if (el('nr-rent'))  el('nr-rent').innerHTML  = Number(d.PercentRentBurdened).toFixed(1) + '%';
+
+        const demoPanel = document.getElementById('nr-demographics');
+        if (demoPanel) demoPanel.style.display = '';
+
+        if (el('nr-zip-list')) {
+            el('nr-zip-list').textContent = d.Zipcodes || '';
+        }
+
+        const zipPanel = document.getElementById('nr-zip-codes');
+        if (zipPanel && d.Zipcodes) zipPanel.style.display = '';
+
+    };
+
+    // --- rendering ---
+
+    const buildIndicatorCard = (row, sectionId, neighborhoodName, accordionParentId) => {
+
+        const accId = nextAccordionId();
+        const headingId = accId + '-h';
+        const collapseId = accId + '-c';
+
+        const value =
+            row.data_value_geo_entity !== null && row.data_value_geo_entity !== undefined
+                ? row.data_value_geo_entity
+                : '–';
+
+        const unitParts = [];
+        if (row.measurement_type) unitParts.push(row.measurement_type);
+        if (row.units) unitParts.push(row.units);
+        const units = unitParts.join(' ').trim();
+
+        // Tertile pill for the header row (production uses .worse/.better/.middle classes)
+        const pillLabel = getTertileLabel(row.data_value_rank, row.rankReverse);
+        const pillClass = getTertilePillClass(row.data_value_rank, row.rankReverse);
+        let pillHTML = '';
+
+        if (pillLabel && pillClass) {
+            pillHTML = '<span class="' + pillClass + '">' + pillLabel + '</span>';
+        }
+
+        const headerHTML =
+            '<div class="card-header border-top" id="' + headingId + '">' +
+                '<h2 class="mb-0">' +
+                '<button class="btn btn-block btn-sm text-left" type="button" ' +
+                    'data-toggle="collapse" data-target="#' + collapseId + '" ' +
+                    'aria-expanded="false" aria-controls="' + collapseId + '">' +
+                    '<div class="row no-gutters d-print-none" style="width:100%">' +
+                        '<div class="col-7">' +
+                            '<span class="font-weight-bold fs-md">' + (row.indicator_short_name || '') + '</span><br>' +
+                            '<span class="fs-sm font-weight-normal">' + (row.indicator_long_name || '') + '</span>' +
+                        '</div>' +
+                        '<div class="col-3 pl-1">' +
+                            '<span class="font-weight-bold fs-lg">' + value + '</span><br>' +
+                            '<span class="fs-xs font-weight-normal">' + units + '</span>' +
+                        '</div>' +
+                        '<div class="col-2">' +
+                            '<div class="float-right mt-1">' + pillHTML + '</div>' +
+                        '</div>' +
+                    '</div>' +
+                '</button>' +
+                '</h2>' +
+            '</div>';
+
+        // Some indicators do not have comparative rank metadata
+        const hasRank = row.data_value_rank != null;
+
+        const boroComp = getComparison(
+            row.unmodified_data_value_geo_entity,
+            row.data_value_boro,
+            row.rankReverse
+        );
+
+        const cityComp = getComparison(
+            row.unmodified_data_value_geo_entity,
+            row.data_value_nyc,
+            row.rankReverse
+        );
+
+        const boroName = row.borough_name || 'Borough';
+        const boroVal = row.data_value_boro != null ? row.data_value_boro : '';
+        const cityVal = row.data_value_nyc != null ? row.data_value_nyc : '';
+
+        let unitSuffix = '';
+        if (row.measurement_type && row.measurement_type.toLowerCase().indexOf('ercent') !== -1) {
+            unitSuffix = '%';
+        } else if (row.units) {
+            unitSuffix = ' ' + row.units;
+        }
+
+        const tertileInlineHTML = getTertileInlineLabel(row.data_value_rank, row.rankReverse);
+
+        const hideClass = hasRank ? '' : ' d-none';
+
+        const comparisonsHTML =
+            '<div class="col-md-5 h-100 p-1' + hideClass + '">' +
+                '<p class="fs-rg">' + (row.indicator_short_name || '') + ' in <strong>' + neighborhoodName + '</strong>:</p>' +
+                '<div class="fs-md">' +
+                    (tertileInlineHTML
+                        ? '<p>' + tertileInlineHTML + '</p>'
+                        : '') +
+                    (boroComp.text
+                        ? '<p><span class="' + boroComp.cssClass + '">' + boroComp.text + '</span> the <strong>' + boroName + ' average</strong>' +
+                        '<br><span class="fs-sm pl-3">(' + boroVal + unitSuffix + ')</span></p>'
+                        : '') +
+                    (cityComp.text
+                        ? '<p><span class="' + cityComp.cssClass + '">' + cityComp.text + '</span> the <strong>Citywide average</strong>' +
+                        '<br><span class="fs-sm pl-3">(' + cityVal + unitSuffix + ')</span></p>'
+                        : '') +
+                '</div>' +
+            '</div>';
+
+        // Keep data-* attributes on the collapse panel for lazy chart rendering
+        const detailHTML =
+            '<div id="' + collapseId + '" class="collapse border-bottom" ' +
+                'aria-labelledby="' + headingId + '" ' +
+                'data-parent="#' + accordionParentId + '" ' +
+                'data-indicator-name="' + (row.indicator_data_name || '') + '" ' +
+                'data-legend-label="' + escapeAttr(units) + '" ' +
+                'data-geocode="' + (row.geo_join_id || row.geo_entity_id || '') + '">' +
+                '<div class="card-body card-body-no-top">' +
+                    '<div class="row no-gutters fs-sm">' +
+                        '<div class="col-12">' +
+                            '<p class="fs-md mt-1 mb-2">' + (row.indicator_description || '') + '</p>' +
+                        '</div>' +
+                        '<div class="col-md-7 border-right h-100">' +
+                            '<div class="nr-map-container" id="map-' + accId + '" style="width:100%;min-height:350px;">' +
+                                '<p class="text-muted small">Chart loads when expanded...</p>' +
+                            '</div>' +
+                        '</div>' +
+                        comparisonsHTML +
+                    '</div>' +
+                    '<div class="row no-gutters">' +
+                        '<div class="col-7">' +
+                            '<p class="fs-xs"><strong>Source:</strong> ' + (row.data_source_list || '') + '</p>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>' +
+            '</div>';
+
+        return headerHTML + detailHTML;
+
+    };
+
+    const renderSection = (section, neighborhoodName) => {
+
+        // Section containers are layout-driven and may be absent in some templates
+        const container = document.getElementById(section.containerId);
+
+        if (!container) return;
+
+        // Neighborhood-level rows are pre-grouped during loadSection
+        const byNeighborhood = sectionData[section.id] || {};
+        const rows = byNeighborhood[neighborhoodName] || [];
+
+        // Reset section contents before re-rendering cards
+        container.innerHTML = '';
+
+        if (!rows.length) {
+            container.innerHTML =
+                '<p class="text-muted px-2 pb-2 mb-0">No data available for this neighborhood.</p>';
+            return;
+        }
+
+        // Create a local accordion parent id so each section collapses independently
+        const accordionParentId = 'nr-accordion-' + section.id;
+
+        rows.forEach(row => {
+
+            const card = document.createElement('div');
+            card.innerHTML = buildIndicatorCard(row, section.id, neighborhoodName, accordionParentId);
+            container.appendChild(card);
+
+        });
+
+    };
+
+    const renderAll = (neighborhoodName, mapGeocode) => {
+
+        // Record the active neighborhood used by downloads and rerenders
+        currentNeighborhood = neighborhoodName;
+        renderedPanels = {};
+        accordionCounter = 0;
+
+        // Start empty and resolve from rows first, then map click, then name lookup
+        currentGeocode = null;
+
+        // Prefer geocodes found directly in loaded rows before fallback lookups
+        for (const sid in sectionData) {
+
+            const nb = sectionData[sid][neighborhoodName];
+
+            if (nb && nb.length) {
+
+                const row0 = nb[0];
+                const gj =
+                    row0.geo_join_id != null && row0.geo_join_id !== ''
+                        ? row0.geo_join_id
+                        : row0.geo_entity_id;
+
+                if (gj != null && gj !== '') {
+                    currentGeocode = gj;
+                    break;
+                }
+
+            }
+
+        }
+
+        // Fall back to the geocode supplied by the map click event
+        if (
+            (currentGeocode == null || currentGeocode === '') &&
+            mapGeocode != null &&
+            mapGeocode !== ''
+        ) {
+            currentGeocode = mapGeocode;
+        }
+
+        // Last resort: resolve geocode by display name from uhflist
+        if (currentGeocode == null || currentGeocode === '') {
+            currentGeocode = getUhfIdForDisplayName(neighborhoodName);
+        }
+
+        config.sections.forEach(section => {
+            renderSection(section, neighborhoodName);
+        });
+
+        // Show the report header and fill in the neighborhood name
+        const reportHeader = document.getElementById('nr-report-header');
+        const headerNeighborhood = document.getElementById('nr-header-neighborhood');
+
+        if (reportHeader) {
+            reportHeader.style.display = '';
+        }
+
+        if (headerNeighborhood) {
+            headerNeighborhood.textContent = neighborhoodName;
+        }
+
+        // Mobile title
+        const mobileTitle = document.getElementById('nr-mobile-title');
+        const mobileNeighborhood = document.getElementById('nr-mobile-neighborhood');
+
+        if (mobileTitle) mobileTitle.style.display = '';
+        if (mobileNeighborhood) mobileNeighborhood.textContent = neighborhoodName;
+
+        renderDemographics(currentGeocode);
+
+        setNeighborhoodInURL(neighborhoodName);
+        updateTopicLinks(neighborhoodName);
+
+    };
+
+    // --- CSV download ---
+
+    const downloadCSV = () => {
+
+        if (!vizTable || !currentNeighborhood) return;
+
+        const csv = vizTable
+            .select(aq.not('report_id', 'indicator_id', 'indicator_data_name', 'start_date', 'end_date'))
+            .filter(aq.escape(d => d.neighborhood === currentNeighborhood))
+            .toCSV();
+
+        const filename = 'NYC EH Data Portal - Neighborhood Report - ' +
+            (config.reportName || 'Report') + ' - ' + currentNeighborhood + '.csv';
+
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+
+        link.href = url;
+        link.download = filename;
+        link.click();
+
+        URL.revokeObjectURL(url);
+
+    };
+
+    window.nrDownloadCSV = downloadCSV;
+
+    // --- Vega map + bar chart ---
+
+    const renderNRMap = (data, destination, legendLabel, geocode) => {
+
+        const boroTopoUrl = config.dataRepo + config.dataBranch + '/geography/borough.topo.json';
+        const uhfTopoUrl = config.dataRepo + config.dataBranch + '/geography/UHF42.topo.json';
+
+        const spec = {
+            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "data": {
+                "values": data,
+                "format": { "parse": { "Value": "number" } }
+            },
+            "config": {
+                "concat": { "spacing": 20 },
+                "view": { "stroke": "transparent" },
+                "axisY": { "domain": false, "ticks": false, "labelBaseline": "bottom" },
+                "legend": { "disable": true },
+                "scale": { "invalid": { "color": { "value": "#808080" } } }
+            },
+            "projection": { "type": "mercator" },
+            "vconcat": [
+                {
+                    "layer": [
+                        {
+                            "height": 300,
+                            "width": "container",
+                            "data": {
+                                "url": boroTopoUrl,
+                                "format": { "type": "topojson", "feature": "collection" }
+                            },
+                            "mark": { "type": "geoshape", "stroke": "#fafafa", "fill": "#C5C5C5", "strokeWidth": 0.5 }
+                        },
+                        {
+                            "height": 300,
+                            "width": "container",
+                            "data": {
+                                "url": uhfTopoUrl,
+                                "format": { "type": "topojson", "feature": "collection" }
+                            },
+                            "mark": { "type": "geoshape", "stroke": "#a2a2a2", "fill": "#e7e7e7", "strokeWidth": 0.5 }
+                        },
+                        {
+                            "height": 300,
+                            "width": "container",
+                            "mark": { "type": "geoshape", "invalid": null },
+                            "transform": [
+                                {
+                                    "lookup": "geo_join_id",
+                                    "from": {
+                                        "data": {
+                                            "url": uhfTopoUrl,
+                                            "format": { "type": "topojson", "feature": "collection" }
+                                        },
+                                        "key": "properties.GEOCODE"
+                                    },
+                                    "as": "geo"
+                                }
+                            ],
+                            "encoding": {
+                                "shape": { "field": "geo", "type": "geojson" },
+                                "color": {
+                                    "field": "unmodified_data_value_geo_entity",
+                                    "type": "quantitative",
+                                    "scale": { "scheme": { "name": "viridis", "extent": [1, 0] } },
+                                    "legend": {
+                                        "direction": "horizontal",
+                                        "orient": "top-left",
+                                        "title": legendLabel,
+                                        "fontWeight": "normal",
+                                        "tickCount": 3,
+                                        "offset": -25,
+                                        "gradientLength": 200
+                                    }
+                                },
+                                "order": {
+                                    "condition": { "test": "datum.geo_join_id == " + geocode, "value": 1 },
+                                    "value": 0
+                                },
+                                "stroke": {
+                                    "condition": { "test": "datum.geo_join_id == " + geocode, "value": "cyan" },
+                                    "value": "#2d2d2d"
+                                },
+                                "strokeWidth": {
+                                    "condition": { "test": "datum.geo_join_id == " + geocode, "value": 2.5 },
+                                    "value": 0.5
+                                },
+                                "tooltip": [
+                                    { "field": "neighborhood", "title": "Neighborhood", "type": "nominal" },
+                                    { "field": "unmodified_data_value_geo_entity", "title": legendLabel, "type": "quantitative" }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "height": 80,
+                    "width": "container",
+                    "mark": { "type": "bar", "tooltip": true, "stroke": "#161616" },
+                    "encoding": {
+                        "y": {
+                            "field": "unmodified_data_value_geo_entity",
+                            "type": "quantitative",
+                            "title": null,
+                            "axis": { "labelAngle": 0, "labelFontSize": 11, "tickCount": 3 }
+                        },
+                        "x": { "field": "geo_join_id", "sort": "y", "axis": null },
+                        "color": {
+                            "field": "unmodified_data_value_geo_entity",
+                            "type": "quantitative",
+                            "scale": { "scheme": { "name": "viridis", "extent": [1, 0] } },
+                            "legend": false
+                        },
+                        "order": {
+                            "condition": { "test": "datum.geo_join_id == " + geocode, "value": 1 },
+                            "value": 0
+                        },
+                        "stroke": {
+                            "condition": { "test": "datum.geo_join_id == " + geocode, "value": "cyan" },
+                            "value": "#2d2d2d"
+                        },
+                        "strokeWidth": {
+                            "condition": { "test": "datum.geo_join_id == " + geocode, "value": 2.5 },
+                            "value": 0
+                        },
+                        "tooltip": [
+                            { "field": "neighborhood", "title": "Neighborhood", "type": "nominal" },
+                            { "field": "unmodified_data_value_geo_entity", "title": legendLabel, "type": "quantitative" }
+                        ]
+                    }
+                }
+            ]
+        };
+
+        vegaEmbed(destination, spec, { actions: true });
+
+    };
+
+    const onAccordionExpand = event => {
+
+        const panel = event.target;
+        const panelId = panel.id;
+
+        // Skip panels that have already been rendered
+        if (renderedPanels[panelId]) return;
+
+        const indicatorName = panel.getAttribute('data-indicator-name');
+        const geocode = panel.getAttribute('data-geocode') || currentGeocode;
+        const mapEl = panel.querySelector('.nr-map-container');
+
+        if (!indicatorName || !mapEl || !vizTable) return;
+
+        try {
+
+            const summaryData = vizTable
+                .filter(aq.escape(d => d.indicator_data_name === indicatorName))
+                .select('geo_join_id', 'neighborhood', 'unmodified_data_value_geo_entity', 'end_date')
+                .dedupe()
+                .groupby('neighborhood')
+                .orderby('neighborhood', aq.desc('end_date'))
+                .slice(0, 1)
+                .ungroup()
+                .derive({ unmodified_data_value_geo_entity: function (d) { return op.parse_float(d.unmodified_data_value_geo_entity); } })
+                .orderby('unmodified_data_value_geo_entity')
+                .select(aq.not('end_date'))
+                .objects();
+
+            if (summaryData.length) {
+
+                mapEl.innerHTML = '';
+
+                let legendLabel = panel.getAttribute('data-legend-label');
+                if (!legendLabel || !String(legendLabel).trim()) {
+                    legendLabel = 'Value';
+                }
+
+                renderNRMap(summaryData, '#' + mapEl.id, legendLabel, geocode);
+
+            } else {
+                mapEl.innerHTML = '<p class="text-muted small">No chart data available.</p>';
+            }
+
+        } catch (e) {
+            console.error('Error rendering map for ' + indicatorName + ':', e);
+            mapEl.innerHTML = '<p class="text-muted small">Unable to render chart.</p>';
+        }
+
+        renderedPanels[panelId] = true;
+
+    };
+
+    // --- Leaflet neighborhood selector map ---
+
+    const defaultStyle = {
+        weight: 1.5,
+        opacity: 1,
+        color: 'black',
+        dashArray: '1',
+        fillOpacity: 0.05,
+        fillColor: '#008939'
+    };
+
+    const highlightStyle = {
+        weight: 3,
+        color: '#008939',
+        dashArray: '3',
+        fillOpacity: 0.5
+    };
+
+    const styleFeature = () => defaultStyle;
+
+    const highlightFeature = e => {
+
+        const layer = e.target;
+        layer.setStyle({ weight: 5, color: '#444', dashArray: '' });
+        layer.bringToFront();
+
+    };
+
+    const resetHighlight = e => {
+
+        const layer = e.target;
+        const geocode = layer.feature.properties.GEOCODE;
+
+        // Preserve the selected neighborhood's highlight on mouseout
+        if (geocode == currentGeocode) return;
+
+        layer.setStyle({ weight: 1.5, color: 'black', dashArray: '1' });
+
+    };
+
+    const selectLayer = (layer, zoom) => {
+
+        if (uhfLayer) uhfLayer.resetStyle();
+
+        layer.setStyle(highlightStyle);
+        layer.bringToFront();
+
+        if (zoom && leafletMap) {
+            leafletMap.flyToBounds(layer.getBounds(), { duration: 0.5 });
+        }
+
+    };
+
+    const geocodeToName = geocode => {
+
+        if (typeof neighborhoods === 'undefined') return null;
+
+        const match = neighborhoods.find(n => n.UHF_id == geocode);
+        if (!match) return null;
+
+        const name = match.UHF_name;
+        return nameCorrections[name] || name;
+
+    };
+
+    const findLayerByGeocode = geocode => {
+
+        if (!uhfLayer) return null;
+
+        let match = null;
+
+        uhfLayer.eachLayer(layer => {
+            if (layer.feature.properties.GEOCODE == geocode) {
+                match = layer;
+            }
+        });
+
+        return match;
+
+    };
+
+    const findLayerByName = name => {
+
+        if (typeof neighborhoods === 'undefined' || !uhfLayer) return null;
+
+        const entry = neighborhoods.find(n => {
+            const corrected = nameCorrections[n.UHF_name] || n.UHF_name;
+            return corrected === name;
+        });
+
+        if (!entry) return null;
+
+        return findLayerByGeocode(entry.UHF_id);
+
+    };
+
+    const onMapClick = e => {
+
+        const layer = e.target;
+        const geocode = layer.feature.properties.GEOCODE;
+        const name = geocodeToName(geocode) || layer.feature.properties.GEONAME;
+
         selectLayer(layer, true);
-      }
-      renderAll(fromURL);
-    }
-  }
 
-  function checkAllLoaded() {
-    fetchesComplete++;
-    if (fetchesComplete >= totalFetches) {
-      dataReady = true;
-      tryInitialRender();
-    }
-  }
+        if (dataReady) {
+            renderAll(name, geocode);
+        }
 
-  // GitHub raw URLs must not contain literal spaces in the path; some clients
-  // reject them or fail inconsistently. Encode the last path segment if needed.
-  function normalizeReportUrl(url) {
-    if (!url || url.indexOf(' ') === -1) return url;
-    try {
-      var u = new URL(url);
-      var parts = u.pathname.split('/').filter(Boolean);
-      if (!parts.length) return url;
-      var last = parts[parts.length - 1];
-      try {
-        last = encodeURIComponent(decodeURIComponent(last));
-      } catch (e) {
-        last = encodeURIComponent(last);
-      }
-      parts[parts.length - 1] = last;
-      u.pathname = '/' + parts.join('/');
-      return u.href;
-    } catch (err) {
-      return url;
-    }
-  }
+    };
 
-  function loadSection(section) {
-    fetch(normalizeReportUrl(section.reportUrl))
-      .then(function (response) {
-        if (!response.ok) throw new Error('HTTP ' + response.status);
-        return response.json();
-      })
-      .then(function (data) {
-        var rows = Array.isArray(data) ? data : [];
-        var byNeighborhood = {};
+    const onEachFeature = (feature, layer) => {
 
-        rows.forEach(function (row) {
-          var n = row.neighborhood;
-          if (!n) return;
-          if (!byNeighborhood[n]) byNeighborhood[n] = [];
-          byNeighborhood[n].push(row);
+        layer.bindTooltip(feature.properties.GEONAME, {
+            permanent: false,
+            opacity: 0.9,
+            className: 'fs-md'
         });
 
-        Object.keys(byNeighborhood).forEach(function (n) {
-          byNeighborhood[n].sort(function (a, b) {
-            var ra = Number(a.data_value_rank);
-            var rb = Number(b.data_value_rank);
-            if (isNaN(ra) || isNaN(rb)) return 0;
-            return rb - ra;
-          });
+        layer.on({
+            mouseover: highlightFeature,
+            mouseout: resetHighlight,
+            click: onMapClick
         });
 
-        sectionData[section.id] = byNeighborhood;
-      })
-      .catch(function (error) {
-        console.error('Error loading section "' + section.id + '":', error);
-        sectionData[section.id] = {};
-      })
-      .then(checkAllLoaded);
-  }
+    };
 
-  function loadVizData() {
-    if (!config.vizUrl) {
-      checkAllLoaded();
-      return;
-    }
+    const initLeafletMap = () => {
 
-    aq.loadJSON(config.vizUrl, { autoMax: 10000, parse: { time: String } })
-      .then(function (table) {
-        vizTable = table;
-      })
-      .catch(function (error) {
-        console.error('Error loading viz data:', error);
-        vizTable = null;
-      })
-      .then(checkAllLoaded);
-  }
+        leafletMap = L.map('nr-map', { zoomControl: false }).setView([40.7128, -74.006], 10);
 
-  // --- init ---
+        L.tileLayer(
+            'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+            {
+                maxZoom: 15,
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+            }
+        ).addTo(leafletMap);
 
-  $(document).on('shown.bs.collapse', '.collapse', onAccordionExpand);
+        L.control.scale({ metric: false, position: 'bottomleft' }).addTo(leafletMap);
 
-  initLeafletMap();
+        fetch(config.geojsonUrl)
+            .then(res => res.json())
+            .then(data => {
 
-  config.sections.forEach(function (section) {
-    loadSection(section);
-  });
-  loadVizData();
-})();
+                uhfLayer = L.geoJSON(data, {
+                    style: styleFeature,
+                    onEachFeature,
+                    filter: feature => feature.properties.GEOCODE != 0
+                }).addTo(leafletMap);
+
+                mapReady = true;
+                tryInitialRender();
+
+            })
+            .catch(err => {
+
+                console.error('Error loading UHF42 GeoJSON:', err);
+                mapReady = true;
+                tryInitialRender();
+
+            });
+
+    };
+
+    // --- data loading ---
+
+    const tryInitialRender = () => {
+
+        if (!dataReady || !mapReady) return;
+
+        const fromURL = getNeighborhoodFromURL();
+
+        if (fromURL) {
+
+            const layer = findLayerByName(fromURL);
+            if (layer) {
+                selectLayer(layer, true);
+            }
+
+            renderAll(fromURL);
+
+        }
+
+    };
+
+    const checkAllLoaded = () => {
+
+        fetchesComplete++;
+
+        // Trigger initial render once all sections and viz data have loaded
+        if (fetchesComplete >= totalFetches) {
+            dataReady = true;
+            tryInitialRender();
+        }
+
+    };
+
+    // GitHub raw URLs must not contain literal spaces in the path; some clients
+    // reject them or fail inconsistently. Encode the last path segment if needed
+    const normalizeReportUrl = url => {
+
+        if (!url || url.indexOf(' ') === -1) return url;
+
+        try {
+
+            const u = new URL(url);
+            const parts = u.pathname.split('/').filter(Boolean);
+
+            if (!parts.length) return url;
+
+            let last = parts[parts.length - 1];
+
+            try {
+                last = encodeURIComponent(decodeURIComponent(last));
+            } catch (e) {
+                last = encodeURIComponent(last);
+            }
+
+            parts[parts.length - 1] = last;
+            u.pathname = '/' + parts.join('/');
+
+            return u.href;
+
+        } catch (err) {
+            return url;
+        }
+
+    };
+
+    const loadSection = section => {
+
+        fetch(normalizeReportUrl(section.reportUrl))
+            .then(res => {
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                return res.json();
+            })
+            .then(data => {
+
+                const rows = Array.isArray(data) ? data : [];
+                const byNeighborhood = {};
+
+                rows.forEach(row => {
+
+                    const n = row.neighborhood;
+                    if (!n) return;
+
+                    if (!byNeighborhood[n]) byNeighborhood[n] = [];
+                    byNeighborhood[n].push(row);
+
+                });
+
+                // Sort each neighborhood's rows by rank descending so higher-ranked
+                // indicators appear at the top of the accordion
+                Object.keys(byNeighborhood).forEach(n => {
+
+                    byNeighborhood[n].sort((a, b) => {
+                        const ra = Number(a.data_value_rank);
+                        const rb = Number(b.data_value_rank);
+                        if (isNaN(ra) || isNaN(rb)) return 0;
+                        return rb - ra;
+                    });
+
+                });
+
+                sectionData[section.id] = byNeighborhood;
+
+            })
+            .catch(error => {
+                console.error('Error loading section "' + section.id + '":', error);
+                sectionData[section.id] = {};
+            })
+            .then(checkAllLoaded);
+
+    };
+
+    const loadVizData = () => {
+
+        if (!config.vizUrl) {
+            checkAllLoaded();
+            return;
+        }
+
+        aq.loadJSON(config.vizUrl, { autoMax: 10000, parse: { time: String } })
+            .then(table => {
+                vizTable = table;
+            })
+            .catch(error => {
+                console.error('Error loading viz data:', error);
+                vizTable = null;
+            })
+            .then(checkAllLoaded);
+
+    };
+
+    // --- init ---
+
+    $(document).on('shown.bs.collapse', '.collapse', onAccordionExpand);
+
+    initLeafletMap();
+
+    config.sections.forEach(section => {
+        loadSection(section);
+    });
+
+    loadVizData();
+
+};
+
+init();

--- a/assets/js/nr-topic-spa.js
+++ b/assets/js/nr-topic-spa.js
@@ -326,7 +326,7 @@ const init = () => {
                 '<button class="btn btn-block btn-sm text-left" type="button" ' +
                     'data-toggle="collapse" data-target="#' + collapseId + '" ' +
                     'aria-expanded="false" aria-controls="' + collapseId + '">' +
-                    '<div class="row no-gutters d-print-none" style="width:100%">' +
+                    '<div class="row no-gutters" style="width:100%">' +
                         '<div class="col-7">' +
                             '<span class="font-weight-bold fs-md">' + (row.indicator_short_name || '') + '</span><br>' +
                             '<span class="fs-sm font-weight-normal">' + (row.indicator_long_name || '') + '</span>' +

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -698,6 +698,9 @@ h2.report-info {
         background: none;
         padding: 8px 0;
     }
+    .nr-map-container {
+        display: none !important;
+    }
 }
 
 // Report Modal

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -698,8 +698,12 @@ h2.report-info {
         background: none;
         padding: 8px 0;
     }
-    .nr-map-container {
+    .card-body-no-top .col-md-7 {
         display: none !important;
+    }
+    .card-body-no-top .col-md-5 {
+        flex: 0 0 100%;
+        max-width: 100%;
     }
 }
 

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -692,6 +692,14 @@ h2.report-info {
     }
 }
 
+@media print {
+    .report-section .btn[data-toggle="collapse"] {
+        border: none;
+        background: none;
+        padding: 8px 0;
+    }
+}
+
 // Report Modal
 
 .report-modal {

--- a/content/data-features/flood-vulnerability-index/index.md
+++ b/content/data-features/flood-vulnerability-index/index.md
@@ -22,7 +22,6 @@ leaflet: true
 js: fvi.js
 image: fvi-preview.png
 related:
-related:
   - title: "What hurricanes teach us about flooding and health"
     url: "data-stories/flooding-and-health/"
   - title: "Heat vulnerability index"

--- a/content/data-features/heat-syndrome/index.md
+++ b/content/data-features/heat-syndrome/index.md
@@ -26,7 +26,6 @@ layout: syndromic
 js: heatsyndrome.js
 image: syndromic.png
 related:
-related:
   - title: "The urban heat island effect in NYC"
     url: "data-stories/urban-heat-island/"
   - title: "Protecting New Yorkers from extreme heat"

--- a/content/data-features/proximity/index.md
+++ b/content/data-features/proximity/index.md
@@ -21,7 +21,6 @@ leaflet: true
 js: proximity.js
 image: preview.png
 related:
-related:
   - title: "Accessibility data"
     url: "data-explorer/accessibility/"
   - title: "Neighborhood boundaries on the EH Data Portal"

--- a/content/data-features/rat-report/2023/index.md
+++ b/content/data-features/rat-report/2023/index.md
@@ -2,7 +2,6 @@
 title: "Rat Mitigation Zone Report: January 2023 to June 2023"
 date: 2021-09-08T11:14:56-04:00
 draft: false
-draft: false
 seo_title: "Rat Mitigation Zone Report"
 seo_description: "Reporting on rat inspection and mitigation work."
 tags: 

--- a/content/data-features/rat-report/2024/index.md
+++ b/content/data-features/rat-report/2024/index.md
@@ -2,7 +2,6 @@
 title: "Rat Mitigation Zone Report: January 2024 to June 2024"
 date: 2024-09-08T11:14:56-04:00
 draft: false
-draft: false
 seo_title: "Rat Mitigation Zone Report"
 seo_description: "Reporting on rat inspection and mitigation work."
 tags: 

--- a/content/data-features/rat-report/index.md
+++ b/content/data-features/rat-report/index.md
@@ -2,7 +2,6 @@
 title: "Rat Mitigation Zone Report: January 2025 to June 2025"
 date: 2025-12-01T11:14:56-04:00
 draft: false
-draft: false
 seo_title: "Rat Mitigation Zone Report"
 seo_description: "Reporting on rat inspection and mitigation work."
 tags: 

--- a/content/data-stories/adult-lead/index.md
+++ b/content/data-stories/adult-lead/index.md
@@ -15,16 +15,6 @@ keywords:
     "worker health",
     "elevated blood lead levels",
   ]
-tags:
-keywords:
-  [
-    "lead",
-    "lead poisoning",
-    "employment",
-    "workers",
-    "worker health",
-    "elevated blood lead levels",
-  ]
 image: OneWorldObservatory_TaggerYanceyIV_6565.jpg
 photocredit: "Tagger Yancey IV/NYC & Company"
 related:

--- a/content/data-stories/air-quality-and-covid-part-2/index.md
+++ b/content/data-stories/air-quality-and-covid-part-2/index.md
@@ -22,20 +22,6 @@ keywords:
     "breathing",
     "restaurants",
   ]
-tags:
-keywords:
-  [
-    "air quality",
-    "traffic",
-    "transportation",
-    "covid",
-    "covid-19",
-    "coronavirus",
-    "air pollution",
-    "lungs",
-    "breathing",
-    "restaurants",
-  ]
 image: ds-aqcovid.jpeg
 photocredit: "Ed Reed/Mayoral Photography Office, City of New York"
 related:

--- a/content/data-stories/racial-wealth-gap/index.md
+++ b/content/data-stories/racial-wealth-gap/index.md
@@ -6,9 +6,7 @@ draft: false
 seo_title: "How the racial wealth gap affects health"
 seo_description: "A data story about how the racial wealth gap affects health."
 tags:
-tags:
 categories: ["inequality"]
-keywords: ["racial wealth gap", "health equity", "inequalities", "inequities"]
 keywords: ["racial wealth gap", "health equity", "inequalities", "inequities"]
 image: CrownHeights_JulienneSchaer-065.JPG
 photocredit: "Julienne Schaer/NYC & Company"

--- a/content/neighborhood-reports/Active_Design_Physical_Activity_and_Health.md
+++ b/content/neighborhood-reports/Active_Design_Physical_Activity_and_Health.md
@@ -3,6 +3,7 @@ title: "Active Design, Physical Activity and Health"
 categories:
   ["airquality", "publicspace", "housing", "inequality", "accessibility"]
 layout: nr-topic-spa
+url: /neighborhood-reports/active_design_physical_activity_and_health/
 content_yml: Active_Design_Physical_Activity_and_Health
 seo_title: "Active Design, Physical Activity and Health in NYC"
 urlExtension: "/active_design_physical_activity_and_health/"

--- a/content/neighborhood-reports/Asthma_and_the_Environment.md
+++ b/content/neighborhood-reports/Asthma_and_the_Environment.md
@@ -11,6 +11,7 @@ categories:
     "healthoutcomes"
   ]
 layout: nr-topic-spa
+url: /neighborhood-reports/asthma_and_the_environment/
 content_yml: Asthma_and_the_Environment
 seo_title: "Asthma and the Environment in NYC"
 urlExtension: "/asthma_and_the_environment/"

--- a/content/neighborhood-reports/Climate_and_Health.md
+++ b/content/neighborhood-reports/Climate_and_Health.md
@@ -2,6 +2,7 @@
 title: "Climate and Health"
 categories: ["climatehealth", "housing", "inequality", "neighborhoods"]
 layout: nr-topic-spa
+url: /neighborhood-reports/climate_and_health/
 content_yml: Climate_and_Health
 seo_title: "Neighborhood reports on climate and health in NYC | Environment and Health Data Portal"
 urlExtension: "/climate_and_health/"

--- a/content/neighborhood-reports/Housing_and_Health.md
+++ b/content/neighborhood-reports/Housing_and_Health.md
@@ -2,6 +2,7 @@
 title: "Housing and Health"
 categories: ["housing", "childhealth", "inequality", "pests"]
 layout: nr-topic-spa
+url: /neighborhood-reports/housing_and_health/
 content_yml: Housing_and_Health
 seo_title: "Housing and Health in NYC"
 urlExtension: "/housing_and_health/"

--- a/content/neighborhood-reports/Outdoor_Air_and_Health.md
+++ b/content/neighborhood-reports/Outdoor_Air_and_Health.md
@@ -2,6 +2,7 @@
 title: "Outdoor Air and Health"
 categories: ["airquality", "childhealth", "publicspace", "neighborhoods"]
 layout: nr-topic-spa
+url: /neighborhood-reports/outdoor_air_and_health/
 content_yml: Outdoor_Air_and_Health
 seo_title: "Outdoor Air and Health in NYC"
 urlExtension: "/outdoor_air_and_health/"

--- a/static/Web.config
+++ b/static/Web.config
@@ -292,8 +292,43 @@
                             
                         </rule>
                         
+                        <!--
+                            NR SPA: internal rewrite for direct/shared links with a neighborhood in the path.
+                            When a user arrives at /neighborhood-reports/{topic}/{neighborhood} (e.g. from a
+                            bookmark or shared link), IIS silently serves the topic page's index.html instead
+                            of returning a 404. The browser URL is unchanged, so the SPA reads the neighborhood
+                            slug from the path and pre-selects it. Internal navigation uses sessionStorage
+                            instead and never hits this rule.
+                        -->
+
+                        <rule name="nr-spa-neighborhood-path" stopProcessing="true">
+
+                            <match url="^neighborhood-reports/(active_design_physical_activity_and_health|asthma_and_the_environment|climate_and_health|housing_and_health|outdoor_air_and_health)/([a-z_]+)/?$" />
+                            <action type="Rewrite" url="neighborhood-reports/{R:1}/" />
+
+                        </rule>
+
+
+                        <!--
+                            NR SPA: permanent 301 redirect for old-style URLs where neighborhood came first.
+                            The old site used /neighborhood-reports/{neighborhood}/{topic}/ (e.g.
+                            /neighborhood-reports/east_new_york/asthma_and_the_environment/). The new SPA
+                            flips the order to /neighborhood-reports/{topic}/{neighborhood}. This rule detects
+                            the old pattern by checking whether the second segment is a known topic slug, then
+                            swaps the two segments. Search engines and bookmarks pointing to old URLs will be
+                            permanently redirected and update their records over time.
+                        -->
+
+                        <rule name="nr-old-to-new-spa" stopProcessing="true">
+
+                            <match url="^neighborhood-reports/([a-z_]+)/(active_design_physical_activity_and_health|asthma_and_the_environment|climate_and_health|housing_and_health|outdoor_air_and_health)/?$" />
+                            <action type="Redirect" url="neighborhood-reports/{R:2}/{R:1}" appendQueryString="false" redirectType="Permanent" />
+
+                        </rule>
+
+
                         <!-- full neighborhood reports path -->
-                        
+
                         <rule name="neighborhood-reports" stopProcessing="true">
                             
                             <match url="^neighborhood_reports/(.*)" />

--- a/themes/dohmh/layouts/404.html
+++ b/themes/dohmh/layouts/404.html
@@ -33,69 +33,65 @@
   </div>
 
 <script>
-// ---------- Get URL, and hide page content options -------------------------------------- // 
+const url = window.location.href;
 
- var url = window.location.href                              // use this when live
+document.querySelectorAll('.chunk').forEach(x => x.classList.add('hide'));
 
-// var url = 'http://localhost:1313/IndicatorPublic/beta'   // test URL
+// ---------- NR SPA: /topic/neighborhood — redirect to topic, restore neighborhood via sessionStorage ---------- //
+//
+// In dev (hugo serve), Hugo has no equivalent of IIS's internal URL rewrite rule, so navigating
+// directly to a neighborhood-specific URL like /neighborhood-reports/asthma_and_the_environment/east_new_york
+// lands here as a 404. We intercept it, store the neighborhood slug in sessionStorage, and redirect
+// to the clean topic URL. When the topic SPA loads, it reads the slug from sessionStorage and
+// pre-selects the neighborhood — the same result as if IIS had handled it transparently.
+//
+// On production this block still runs for any genuinely broken NR URLs (e.g. a mistyped neighborhood
+// slug that doesn't match the IIS rewrite rule), providing a graceful fallback rather than a dead end.
 
-var chunks = document.querySelectorAll('.chunk')
+// The 5 NR topic slugs — these match the url: frontmatter on the SPA content files
+const nrTopicSlugs = [
+  'active_design_physical_activity_and_health',
+  'asthma_and_the_environment',
+  'climate_and_health',
+  'housing_and_health',
+  'outdoor_air_and_health'
+];
 
-chunks.forEach(x => x.classList.add('hide'))
+// Split the path into segments and find which one is a known topic slug
+const pathParts = window.location.pathname.replace(/\/$/, '').split('/').filter(Boolean);
+const topicIdx = pathParts.findIndex(p => nrTopicSlugs.includes(p));
 
+// If a topic slug is found and there is a segment after it, treat that segment as the neighborhood slug
+if (topicIdx !== -1 && pathParts.length > topicIdx + 1) {
+  sessionStorage.setItem('nr_pending_neighborhood', pathParts[topicIdx + 1]);
+  window.location.replace({{ relURL "neighborhood-reports/" }} + pathParts[topicIdx] + '/');
+} else if (url.includes('beta')) {
+  removeBeta(url);
+} else {
+  redirectHome();
+}
 
-// ---------- does the URL include beta? ---------- // 
-
-url.includes("beta") ? removeBeta(url) : redirectHome()
-
-
-// ----------  remove /beta from URL and redirect to otherwise same URL -------------------- // 
+// ----------  remove /beta from URL and redirect to otherwise same URL -------------------- //
 
 function removeBeta(x) {
-  // expose page content
-  document.getElementById('redirectBeta').classList.remove('hide')
-  //console.log('It is a beta URL')
-
-  // remove beta from URL
-  url = x.replace('/beta','')
-  // console.log('new url: ', url)
-
-  // send to new location
-  setTimeout(() => {
-    window.location.href = url
-  }, 2000)
+  document.getElementById('redirectBeta').classList.remove('hide');
+  setTimeout(() => { window.location.href = x.replace('/beta', ''); }, 2000);
 }
 
-// ----------  redirect to Home Page -------------------------------------------------------- // 
+// ----------  redirect to Home Page -------------------------------------------------------- //
 
 function redirectHome() {
-  // expose content
-  document.getElementById('main404').classList.remove('hide')
-
-  // start countdown
-  countDown(5)
+  document.getElementById('main404').classList.remove('hide');
+  countDown(5);
 }
-
 
 function countDown(x) {
-
   if (x > 0) {
-    var print = document.getElementById('sec')
-    print.innerHTML = x
-    var oneLess = x - 1
-    setTimeout(() => {
-      countDown(oneLess)
-    }, 1000)
-
+    document.getElementById('sec').innerHTML = x;
+    setTimeout(() => { countDown(x - 1); }, 1000);
   } else {
-    sendHome()
+    setTimeout(() => { window.location.href = {{ relURL "" }}; }, 1000);
   }
-}
-
-function sendHome() {
-  setTimeout(() => {
-    window.location.href = {{ relURL "" }}
-  }, 1000)
 }
 
 </script>

--- a/themes/dohmh/layouts/neighborhood-reports/nr-topic-spa.html
+++ b/themes/dohmh/layouts/neighborhood-reports/nr-topic-spa.html
@@ -85,6 +85,12 @@
   #nr-map:hover {
     cursor: pointer;
   }
+  @media print {
+    .col-print-12 {
+      max-width: 100%;
+      flex: 0 0 100%;
+    }
+  }
 </style>
 
 <section class="container-fluid" id="skip-header-target">
@@ -166,7 +172,7 @@
         </div>
 
         {{/* Right column: topic buttons + report header + sections */}}
-        <div class="col-md-8">
+        <div class="col-md-8 col-print-12">
 
           {{/*
             Topic mini-menu: row of buttons matching the production layout.

--- a/themes/dohmh/layouts/neighborhood-reports/nr-topic-spa.html
+++ b/themes/dohmh/layouts/neighborhood-reports/nr-topic-spa.html
@@ -90,6 +90,10 @@
       max-width: 100%;
       flex: 0 0 100%;
     }
+    /* Ensure expanded accordion bodies remain visible in print */
+    .collapse.show {
+      display: block !important;
+    }
   }
 </style>
 

--- a/themes/dohmh/layouts/neighborhood-reports/nr-topic-spa.html
+++ b/themes/dohmh/layouts/neighborhood-reports/nr-topic-spa.html
@@ -175,38 +175,47 @@
         <div class="col-md-8 col-print-12">
 
           {{/*
-            Topic mini-menu: row of buttons matching the production layout.
-            The "nr-topic-link" class is used by the JS to rewrite hrefs
-            with the current ?neighborhood= param for persistence.
+            Topic mini-menu: row of buttons for switching between the 5 NR topic pages.
+            The "nr-topic-link" class is used by the JS to attach an onclick handler that
+            stores the active neighborhood slug in sessionStorage before navigating, so the
+            destination topic page can pre-select the same neighborhood on load.
+            Hrefs point to the clean topic URL (no neighborhood in the path) — the
+            neighborhood is carried via sessionStorage, not the URL, to avoid 404s in dev
+            and to keep navigation independent of IIS rewrite rules.
           */}}
           <div class="row no-gutters d-print-none mb-2">
             <div class="col-sm mb-2 mr-1 mb-lg-0">
               <a class="btn btn-sm btn-block btn-outline-primary text-decoration-none btn-light-green-bg py-2 nr-topic-link{{ if eq $contentKey "Active_Design_Physical_Activity_and_Health" }} active{{ end }}"
-                 href="{{ relURL "neighborhood-reports/Active_Design_Physical_Activity_and_Health/" }}">
+                 href="{{ relURL "neighborhood-reports/active_design_physical_activity_and_health/" }}"
+>
                 Active Design
               </a>
             </div>
             <div class="col-sm mb-2 mr-1 mb-lg-0">
               <a class="btn btn-sm btn-block btn-outline-primary text-decoration-none btn-light-green-bg py-2 nr-topic-link{{ if eq $contentKey "Asthma_and_the_Environment" }} active{{ end }}"
-                 href="{{ relURL "neighborhood-reports/Asthma_and_the_Environment/" }}">
+                 href="{{ relURL "neighborhood-reports/asthma_and_the_environment/" }}"
+>
                 Asthma
               </a>
             </div>
             <div class="col-sm mb-2 mr-1 mb-lg-0">
               <a class="btn btn-sm btn-block btn-outline-primary text-decoration-none btn-light-green-bg py-2 nr-topic-link{{ if eq $contentKey "Climate_and_Health" }} active{{ end }}"
-                 href="{{ relURL "neighborhood-reports/Climate_and_Health/" }}">
+                 href="{{ relURL "neighborhood-reports/climate_and_health/" }}"
+>
                 Climate
               </a>
             </div>
             <div class="col-sm mb-2 mr-1 mb-lg-0">
               <a class="btn btn-sm btn-block btn-outline-primary text-decoration-none btn-light-green-bg py-2 nr-topic-link{{ if eq $contentKey "Housing_and_Health" }} active{{ end }}"
-                 href="{{ relURL "neighborhood-reports/Housing_and_Health/" }}">
+                 href="{{ relURL "neighborhood-reports/housing_and_health/" }}"
+>
                 Housing
               </a>
             </div>
             <div class="col-sm mb-2 mr-1 mb-lg-0">
               <a class="btn btn-sm btn-block btn-outline-primary text-decoration-none btn-light-green-bg py-2 nr-topic-link{{ if eq $contentKey "Outdoor_Air_and_Health" }} active{{ end }}"
-                 href="{{ relURL "neighborhood-reports/Outdoor_Air_and_Health/" }}">
+                 href="{{ relURL "neighborhood-reports/outdoor_air_and_health/" }}"
+>
                 Outdoor Air
               </a>
             </div>
@@ -301,7 +310,23 @@
           "reportUrl": "{{ $url }}"
         }
       {{- end -}}
-    ]
+    ],
+    // URL slug for this topic page, e.g. "asthma_and_the_environment".
+    // Used by setNeighborhoodInURL to locate the topic segment in the current path
+    // when updating the address bar after a neighborhood is selected.
+    topicSlug: "{{ .RelPermalink | strings.TrimSuffix "/" | path.Base }}",
+    // Mapping of neighborhood URL slug → display name for all 42 UHF neighborhoods,
+    // e.g. { "east_new_york": "East New York", ... }. Generated at build time by Hugo
+    // from the neighborhood section content files so it stays in sync automatically.
+    // Used by getNeighborhoodFromURL (slug → name) and setNeighborhoodInURL (name → slug).
+    neighborhoodMap: {
+      {{- $nrSections := ($.Site.GetPage "/neighborhood-reports").Sections -}}
+      {{- range $i, $p := $nrSections -}}
+        {{- $slug := $p.RelPermalink | strings.TrimSuffix "/" | path.Base -}}
+        {{- if $i }},{{ end -}}
+        "{{ $slug }}": "{{ $p.Title }}"
+      {{- end -}}
+    }
   };
 </script>
 

--- a/themes/dohmh/layouts/neighborhood-reports/section.html
+++ b/themes/dohmh/layouts/neighborhood-reports/section.html
@@ -308,7 +308,12 @@ function loadList() {
     // console.log('chosen neighb:')
     // console.log(set.page_name);
 
-    window.location.href = {{ relURL "neighborhood-reports/" }} + intendedDestinationName + '/?neighborhood=' + encodeURIComponent(set.UHF_name)
+    // Store the neighborhood slug before navigating to the topic SPA page.
+    // The SPA reads this from sessionStorage on load and pre-selects the neighborhood.
+    // We navigate to the clean topic URL (no neighborhood in the path) so the request
+    // always resolves to a real static file, both in dev and on production.
+    sessionStorage.setItem('nr_pending_neighborhood', set.page_name);
+    window.location.href = {{ relURL "neighborhood-reports/" }} + intendedDestinationName + '/'
 
 })
 

--- a/themes/dohmh/layouts/neighborhood-reports/section.html
+++ b/themes/dohmh/layouts/neighborhood-reports/section.html
@@ -9,7 +9,7 @@
   </style>
 
   <div class="row mb-4">
-    <div class="col-lg-12 mx-auto col-12">
+    <div class="col-lg-10 mx-auto col-12">
       <nav aria-label="breadcrumb" class="mt-2 mb-3">
         <ul class="breadcrumb">
             <li class="breadcrumb-item"><a href={{ relURL "" }}>Home</a></li>
@@ -308,7 +308,7 @@ function loadList() {
     // console.log('chosen neighb:')
     // console.log(set.page_name);
 
-    window.location.href = {{ relURL "neighborhood-reports/" }} + set.page_name + '/' + intendedDestinationName
+    window.location.href = {{ relURL "neighborhood-reports/" }} + intendedDestinationName + '/?neighborhood=' + encodeURIComponent(set.UHF_name)
 
 })
 

--- a/themes/dohmh/layouts/nr-output/section.html
+++ b/themes/dohmh/layouts/nr-output/section.html
@@ -46,11 +46,11 @@
                 </div>
                 {{- end -}}
                   <div class="card-body p-2">
-                      <h2 class="card-title fs-md"><a href="{{ relURL "neighborhood-reports/" }}{{ .File.BaseFileName }}/?neighborhood={{ $.Title | urlquery }}" class="text-primary fs-lg">{{ .Title }}</a></h2>
+                      <h2 class="card-title fs-md"><a href="{{ relURL "neighborhood-reports/" }}{{ .File.BaseFileName | lower }}/" class="text-primary fs-lg">{{ .Title }}</a></h2>
                       <p class="card-text fs-sm">
                           {{ .Summary | truncate 150}}
                           </p>
-                         <p class="fs-sm text-right"> <a href="{{ relURL "neighborhood-reports/" }}{{ .File.BaseFileName }}/?neighborhood={{ $.Title | urlquery }}">See&nbsp;report&nbsp;<i class="fas fa-arrow-circle-right"></i></a>
+                         <p class="fs-sm text-right"> <a href="{{ relURL "neighborhood-reports/" }}{{ .File.BaseFileName | lower }}/">See&nbsp;report&nbsp;<i class="fas fa-arrow-circle-right"></i></a>
                         </p>                   
                     </div>
                   </div>
@@ -61,6 +61,16 @@
 
           </div>
         </div>
+
+<script>
+    // Store neighborhood slug before navigating to a topic page, so the SPA can pre-select it
+    const _nrNeighborhoodSlug = '{{ .RelPermalink | strings.TrimSuffix "/" | path.Base }}';
+    document.querySelectorAll('.card a').forEach(a => {
+        a.addEventListener('click', () => {
+            sessionStorage.setItem('nr_pending_neighborhood', _nrNeighborhoodSlug);
+        });
+    });
+</script>
 
       </div>
 

--- a/themes/dohmh/layouts/nr-output/section.html
+++ b/themes/dohmh/layouts/nr-output/section.html
@@ -3,7 +3,7 @@
 <div>
   <div class="container-fluid">
     <div class="row">
-      <div class="col-lg-12 mx-auto col-sm-12">
+      <div class="col-lg-10 mx-auto col-sm-12">
         <!-- content goes here -->
         <nav aria-label="breadcrumb" class="mt-2 mb-3">
           <ul class="breadcrumb">
@@ -46,11 +46,11 @@
                 </div>
                 {{- end -}}
                   <div class="card-body p-2">
-                      <h2 class="card-title fs-md"><a href="{{ .RelPermalink }}" class="text-primary fs-lg">{{ .Title }}</a></h2>
+                      <h2 class="card-title fs-md"><a href="{{ relURL "neighborhood-reports/" }}{{ .File.BaseFileName }}/?neighborhood={{ $.Title | urlquery }}" class="text-primary fs-lg">{{ .Title }}</a></h2>
                       <p class="card-text fs-sm">
                           {{ .Summary | truncate 150}}
                           </p>
-                         <p class="fs-sm text-right"> <a href="{{ .RelPermalink }}">See&nbsp;report&nbsp;<i class="fas fa-arrow-circle-right"></i></a>
+                         <p class="fs-sm text-right"> <a href="{{ relURL "neighborhood-reports/" }}{{ .File.BaseFileName }}/?neighborhood={{ $.Title | urlquery }}">See&nbsp;report&nbsp;<i class="fas fa-arrow-circle-right"></i></a>
                         </p>                   
                     </div>
                   </div>

--- a/themes/dohmh/layouts/nr-output/single.html
+++ b/themes/dohmh/layouts/nr-output/single.html
@@ -610,7 +610,7 @@ buttons.forEach(button => {
             urlParts.pop();
             console.log(urlParts)
 
-        var newURL = `{{ .Site.BaseURL }}` + urlParts[0] + '/' + urlParts[1] + '/' + reportDestination + '/'
+        var newURL = `{{ .Site.BaseURL }}` + 'neighborhood-reports/' + reportDestination + '/?neighborhood=' + encodeURIComponent(NeighborhoodName)
         console.log(newURL)
 
         window.location.href = newURL

--- a/themes/dohmh/layouts/nr-output/single.html
+++ b/themes/dohmh/layouts/nr-output/single.html
@@ -92,6 +92,17 @@
     let thisInd;
     let NeighborhoodName = "{{ $.Params.neighborhood }}"; // setting for use in visualizations
 
+    // The old site served neighborhood+topic pages at /neighborhood-reports/{neighborhood}/{topic}/.
+    // The new SPA uses the reversed order: /neighborhood-reports/{topic}/{neighborhood}.
+    // Any user or search engine arriving at an old URL is immediately sent to the correct new URL
+    // using window.location.replace (which replaces the history entry, so the back button skips
+    // the old page). On production, the IIS 301 redirect rule fires before this page even loads,
+    // so this JS redirect is primarily a dev fallback and a safety net for any edge cases IIS misses.
+    const _nrParts = window.location.pathname.replace(/\/$/, '').split('/').filter(Boolean);
+    const _nrNeighborhood = _nrParts[_nrParts.length - 2];
+    const _nrTopic = _nrParts[_nrParts.length - 1];
+    window.location.replace(`{{ .Site.BaseURL }}` + 'neighborhood-reports/' + _nrTopic + '/' + _nrNeighborhood);
+
     // this gets a json of topics and nested indicators
     async function get_topic_indicators() {
         d3.json('{{ relURL "IndicatorMetadata/topic_indicators.json" }}').then(data => {
@@ -597,21 +608,8 @@ const buttons = document.querySelectorAll('.output-topic-button');
 
 buttons.forEach(button => {
     button.addEventListener('click', () => {
-        console.log('button clicked for: ', button.id)
-
-        // change URL destination in a way that matches topicSlugs 
         const reportDestination = topicSlugs[button.id] || null;
-
-        // assemble new url
-        const pageURL = window.location.pathname.match(/neighborhood-reports.*/)[0]
-        var urlParts = pageURL.split('/')
-
-            urlParts.pop();
-            urlParts.pop();
-            console.log(urlParts)
-
-        var newURL = `{{ .Site.BaseURL }}` + 'neighborhood-reports/' + reportDestination + '/?neighborhood=' + encodeURIComponent(NeighborhoodName)
-        console.log(newURL)
+        const newURL = `{{ .Site.BaseURL }}` + 'neighborhood-reports/' + reportDestination + '/{{ $.CurrentSection.RelPermalink | strings.TrimSuffix "/" | path.Base }}';
 
         window.location.href = newURL
 

--- a/themes/dohmh/layouts/partials/nr-leaflet.html
+++ b/themes/dohmh/layouts/partials/nr-leaflet.html
@@ -318,7 +318,7 @@
             
             // Build the new path; this will now work if reportURL is set (as in the Output), or if it's not (as on a Neighborhood Landing Page)
             
-            const buildURL = {{ relURL "neighborhood-reports/" }} + parts[3] + "/" + dest + '/'
+            const buildURL = {{ relURL "neighborhood-reports/" }} + dest + '/?neighborhood=' + encodeURIComponent(match.UHF_name)
             
             // Redirect - send to new page
             window.location.href = buildURL;

--- a/themes/dohmh/layouts/partials/nr-leaflet.html
+++ b/themes/dohmh/layouts/partials/nr-leaflet.html
@@ -318,8 +318,11 @@
             
             // Build the new path; this will now work if reportURL is set (as in the Output), or if it's not (as on a Neighborhood Landing Page)
             
-            const buildURL = {{ relURL "neighborhood-reports/" }} + dest + '/?neighborhood=' + encodeURIComponent(match.UHF_name)
-            
+            const buildURL = {{ relURL "neighborhood-reports/" }} + dest + '/'
+
+            // Store neighborhood slug so the SPA can pre-select it without a full-path URL
+            sessionStorage.setItem('nr_pending_neighborhood', match.page_name);
+
             // Redirect - send to new page
             window.location.href = buildURL;
             // console.log(buildURL)


### PR DESCRIPTION
@cgettings We will be following up via email, but here is a rundown of what was done in this latest effort. 

1. Claude was introduced to the project via a generated CLAUDE.md file. This file contains information about the project and instructions for Claude to reference during development
2. A Claude skill was created within the project to dictate preferences for how javascript is developed by Claude. We can move this skill out into a separate repo if desired, and have it be leveraged as a plugin.
3. Claude skill was leverage to apply the development practices preferred based on feedback from DOHMH. Site functionality was tested after these code adjustments were made.
4. Print styles were adjusted so the information on our new neighborhood report template are printed clearly. 
5. The new flow was applied to the main Neighborhood Reports page, as well as the See Neighborhood List landing pages.
6. URLs were reconfigured to not use the neighborhood URL paramater (?neighborhood=Sunset+Park) and instead use a URL segment that looks nicer (/sunset_park/)
7. Set up IIS rules to handle redirects for the old pages to the new pages, as well as some helper code for local development, when IIS is not available.
8. Investigated map zoom request, but it seems to match what is currently in place on the live site.
9. A handful of content files contained duplicate frontmatter data. It seems in newer versions of Hugo, this will break the build. These duplicates were removed, and can be seen in the commits in the PR. 