### PR TITLE
fix: correct "Soho" to "SoHo" so Greenwich Village reports show their data

### DIFF
--- a/content/neighborhood-reports/Greenwich_Village_SoHo/Active_Design_Physical_Activity_and_Health.md
+++ b/content/neighborhood-reports/Greenwich_Village_SoHo/Active_Design_Physical_Activity_and_Health.md
@@ -1,6 +1,6 @@
 ---
 title: "Active Design, Physical Activity and Health"
-neighborhood: "Greenwich Village - Soho"
+neighborhood: "Greenwich Village - SoHo"
 geocode: 308
 summary: "The design and conditions of buildings, streets, public transportation and parks influence physical activity, use of active transportation and other healthy behavior. A neighborhood's features can also impact the safety of its residents."
 data_json: "Active Design Physical Activity and Health in Greenwich Village - SoHo"

--- a/content/neighborhood-reports/Greenwich_Village_SoHo/Asthma_and_the_Environment.md
+++ b/content/neighborhood-reports/Greenwich_Village_SoHo/Asthma_and_the_Environment.md
@@ -1,6 +1,6 @@
 ---
 title: "Asthma and the Environment"
-neighborhood: "Greenwich Village - Soho"
+neighborhood: "Greenwich Village - SoHo"
 geocode: 308
 summary: "Asthma is a common lung disease and a leading cause of hospitalizations for children under 15 years old. This report provides a summary of asthma indicators by neighborhood. It also describes housing and neighborhood characteristics that can make asthma worse."
 data_json: "Asthma and the Environment in Greenwich Village - SoHo"

--- a/content/neighborhood-reports/Greenwich_Village_SoHo/Climate_and_Health.md
+++ b/content/neighborhood-reports/Greenwich_Village_SoHo/Climate_and_Health.md
@@ -1,6 +1,6 @@
 ---
 title: "Climate and Health"
-neighborhood: "Greenwich Village - Soho"
+neighborhood: "Greenwich Village - SoHo"
 geocode: 308
 summary: "Extreme heat, coastal storms, flooding and episodes of elevated ozone are climate-related hazards that may increase with climate change and have important public health impacts in New York City. Extreme weather can cause power outages, which also threaten public health. This report provides neighborhood indicators of climate-related hazards, vulnerability and health impacts."
 data_json: "Climate and Health in Greenwich Village - SoHo"

--- a/content/neighborhood-reports/Greenwich_Village_SoHo/Housing_and_Health.md
+++ b/content/neighborhood-reports/Greenwich_Village_SoHo/Housing_and_Health.md
@@ -1,6 +1,6 @@
 ---
 title: "Housing and Health"
-neighborhood: "Greenwich Village - Soho"
+neighborhood: "Greenwich Village - SoHo"
 geocode: 308
 summary: "This report provides a neighborhood summary of housing conditions and related health outcomes. It also describes population characteristics that can increase vulnerability to housing hazards."
 data_json: "Housing and Health in Greenwich Village - SoHo"

--- a/content/neighborhood-reports/Greenwich_Village_SoHo/Outdoor_Air_and_Health.md
+++ b/content/neighborhood-reports/Greenwich_Village_SoHo/Outdoor_Air_and_Health.md
@@ -1,6 +1,6 @@
 ---
 title: "Outdoor Air and Health"
-neighborhood: "Greenwich Village - Soho"
+neighborhood: "Greenwich Village - SoHo"
 geocode: 308
 summary: "Air pollution is one of the most important environmental threats to urban populations and while all people are exposed, pollutant emissions, levels of exposure, and population vulnerability vary across neighborhoods. Exposures to common air pollutants have been linked to respiratory and cardiovascular diseases, cancers, and premature deaths."
 data_json: "Outdoor Air and Health in Greenwich Village - SoHo"

--- a/content/neighborhood-reports/Greenwich_Village_SoHo/_index.md
+++ b/content/neighborhood-reports/Greenwich_Village_SoHo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Greenwich Village - SoHo
 type: nr-output
-seo_title: "Greenwich Village - Soho"
+seo_title: "Greenwich Village - SoHo"
 geocode: 308
 seo_description: "Environmental Health data profiles for the Greenwich Village - SoHo neighborhood of NYC."
 seo_image: ""


### PR DESCRIPTION
## The bug

The five **Greenwich Village – SoHo** neighborhood report pages render their report-topic headings and prose but **zero indicator cards**. This is live now.

`themes/dohmh/layouts/nr-output/single.html:419` selects the rows for a page with:

```go-html-template
{{- $neighborhood_topic_data := where $topic_data "neighborhood" $.Params.neighborhood -}}
```

The frontmatter said `neighborhood: "Greenwich Village - Soho"`, while both EHDP-data's report JSON and the `uhflist` rows use `"Greenwich Village - SoHo"`. The filter matched nothing, so the range that builds the indicator cards ran zero times.

Roughly 61 sessions a year across the five pages.

## Evidence

Checked against the live site *before* changing anything:

| page | `id="heading-"` occurrences |
|---|---|
| `/neighborhood-reports/greenwich_village_soho/asthma_and_the_environment/` | **0** |
| `/neighborhood-reports/east_harlem/asthma_and_the_environment/` (control) | 22 |

With this change applied, a `--environment production` build renders **22 for both**. That build ran on the `feature-MOD-Lab-NR-recode-refactor` branch where the bug was found, but the `where` line is byte-identical there and on `production`, so the mechanism is the same.

## Scope

An exhaustive sweep of all 210 topic frontmatter files against `uhflist`'s `UHF_name` found **these five and no others**.

Six lines change: the five `neighborhood:` values, plus a cosmetic `seo_title:` on `_index.md` carrying the same misspelling. Every other `SoHo` string in these files was already correct.

Left alone deliberately: the `Greenwich Village and Soho` rows in `content/data-features/minimum-wage/data/map-data.csv` are a different dataset with its own naming convention.

## Why it is safe

Normalising `Soho` → `SoHo` makes the removed and added lines byte-identical, so the diff contains nothing but the substitution.

## Context

Found while pre-capturing the old `nr-output` pages ahead of the Neighborhood Reports retirement work. That work would have fixed this incidentally, since it generates pages from `uhflist`'s spelling — but the bug is live and independent of it, so it goes to `production` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
