### PR TITLE
Check a named environment's characterization, in an isolated server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ npm run characterize:site:baseline   # re-capture this environment's baseline â€
 npm run characterize:site:prod_prod   # the same check against an isolated prod_prod server
 npm run characterize:site:dev_stage   # ditto, dev_stage
 npm run characterize:site:env local_prod   # ditto, any environment in config/
+npm run characterize:site:env local_prod sample   # ditto, over the 41-page sample
 node scripts/site-characterization.mjs --check --content   # widen the gate to titles and link targets
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,9 @@ Seven things to know before trusting a result:
 npm run characterize:site            # every page, diff `structure` against the committed baseline
 npm run characterize:site:sample     # the same check over 41 pages, one per template kind
 npm run characterize:site:baseline   # re-capture this environment's baseline — commit the result
+npm run characterize:site:prod_prod   # the same check against an isolated prod_prod server
+npm run characterize:site:dev_stage   # ditto, dev_stage
+npm run characterize:site:env local_prod   # ditto, any environment in config/
 node scripts/site-characterization.mjs --check --content   # widen the gate to titles and link targets
 ```
 
@@ -88,6 +91,26 @@ are printed as a harness-health number and deliberately **not** baselined — th
   CloudCannon commits content directly, so a check that also gated on titles and link text would
   fail on commits that never touch a template — and a check that fails routinely stops being read.
   `--content` widens it when you want that.
+- **`characterize:site` checks whichever environment your machine happens to be serving; the
+  `:env` scripts pick one.** `dev-server.mjs` reuses any server answering on :8080/:8081/:1313 and
+  otherwise spawns `dev_stage` into the repo's own `docs/` and `resources/_gen`, so what
+  `characterize:site` compares depends on what you have running. `scripts/characterize-env.mjs`
+  ignores running servers entirely: it spawns the named environment on :8090 with `-d` and
+  `HUGO_RESOURCEDIR` redirected outside the repo, builds Pagefind into that isolated `publishDir`,
+  runs `--check --all` against it, and stops it. Slower — a cold isolated build runs before the
+  sweep, and `rebaseline.mjs` allows 200s for the server alone — and it leaves `docs/` and
+  `resources/_gen` untouched. Use `characterize:site` by default; use `:prod_prod` when the
+  question is about the site that actually deploys.
+- **Arguments to these are POSITIONAL, and that is not a style choice.** Measured 2026-08-26 (npm
+  11.4.1, PowerShell): `npm run x -- --env prod_prod` reaches the script as `argv ["prod_prod"]` —
+  PowerShell eats the `--` and npm eats the flag *name*, leaving its value as a nameless
+  positional, so `--concurrency 8` arrives as a bare `"8"`. A plain positional survives both
+  intact. `characterize-env.mjs` therefore refuses any argument starting with `-` rather than
+  half-honour it; flags stay available through a direct `node scripts/site-characterization.mjs`
+  call. For the same reason `site-characterization-rebaseline.mjs` now refuses unrecognized
+  arguments outright: it takes none, it re-captures *every* committed baseline on every run, and
+  an argument it merely ignored made a typo indistinguishable from the destructive invocation
+  `[2026-08-26: `rebaseline.mjs nosuchkey`, believed to name one key, began re-capturing both]`.
 - **Baselines are filed by environment class, and `--check` picks its own.** They live under
   `scripts/site-characterization-baseline/<key>/`, and the harness reads the key off the running
   site — it prints `Environment: dev_stage (EHDP-data staging) at /dev-stage/ — baseline

--- a/documents/characterize-env-plan-2026-08-26.md
+++ b/documents/characterize-env-plan-2026-08-26.md
@@ -1,9 +1,9 @@
 # Per-environment characterization invocation
 
 **Status as of 2026-08-26: branch `feature-characterize-env` cut from `production` at
-`3d5438830c`; tasks 1-6 done at `d14ab4e841` and `4a91dd94f9`. The tooling works. One page
-differs on `prod_prod` that this branch did not cause, and it REPRODUCES exactly — open, and
-awaiting a decision (investigate / re-baseline / leave).**
+`3d5438830c`; tasks 1-6 done at `d14ab4e841` and `4a91dd94f9`, task 7 (human-facing docs) and the
+diagnosis of the `prod_prod` diff done and uncommitted. The diff is a live-data marker count, not
+a regression — nothing to fix in this repo, but the `img` field is unstable on any map page.**
 
 ## Why
 
@@ -120,14 +120,29 @@ first, gave the identical page, the identical two fields and the identical numbe
 16 -> 15). So this is a stable difference between the site as it renders now and the baseline
 captured 2026-08-25, not a capture flake.
 
-**Still not established: which `<img>` went.** The record stores counts only, and `assets` cannot
-narrow it — `assetNodes` (`site-characterization.mjs:329`) covers `script[src]` and
-`link[rel=stylesheet][href]` alone, so images were never in that field and its being unchanged
-means nothing here. Answering it needs the page loaded and its non-tile `<img>` set dumped.
+**Diagnosed 2026-08-26: it is one fewer map marker, drawn from live data.** The page was loaded
+twice against an isolated `prod_prod` server and every `<img>` dumped with its class, `alt`, box and
+`src`. Both passes: 30 images, 10 of them `.leaflet-tile` (excluded by the harness), and **exactly
+15 `images/map-marker.svg` — every one of them with no `alt` attribute, and the only alt-less
+images on the page.** The harness reads `missingAlt` 15 against a baseline of 16. So the marker
+count went 16 -> 15, and `total` moved by the same 1.
 
-**Consequence while it stands:** `npm run characterize:site:prod_prod` exits 1 for everyone. Three
-ways out, and the choice is the user's: find and fix the cause; re-capture the `prod_prod` baseline
-if the change is intended; or leave it recorded here as a known red.
+Markers on this page are one per live air-quality monitor, so the count is a fact about the feed
+that day, not about the site. **Nothing to fix in this repo.**
+
+(The probe counted 20 non-tile images where the harness counts 18. The three the harness sees
+besides markers are the two NYC logos and the portal icon; the two it does not are the Google
+Translate widget's. `blockedHosts` in `_meta.json` lists `translate.google.com`,
+`translate.googleapis.com`, `www.gstatic.com` and `www.googletagmanager.com`, so the widget cannot
+initialize under the harness — consistent with the arithmetic, though not separately confirmed.)
+
+**The general finding, which outlives this page:** `structure.img.total` and
+`structure.img.missingAlt` track marker counts on any page whose map draws from live data.
+`site-characterization.mjs:398` excludes `.leaflet-tile` and the comment there says marker icons
+deliberately still count — that exclusion was written for tile *timing*, and does not cover a
+marker set whose size is data-driven. Such a page goes red whenever the feed moves, with no
+code change. Worth deciding separately from this branch: exclude marker icons too, or accept
+periodic re-baselines.
 
 ## Environment state
 

--- a/documents/characterize-env-plan-2026-08-26.md
+++ b/documents/characterize-env-plan-2026-08-26.md
@@ -1,0 +1,114 @@
+# Per-environment characterization invocation
+
+**Status as of 2026-08-26: branch `feature-characterize-env` cut from `production` at
+`3d5438830c`; task 1 done at `d14ab4e841`, tasks 2-5 not started.**
+
+## Why
+
+`npm run characterize:site` can only check the environment `scripts/dev-server.mjs` happens to
+resolve — it reuses whatever answers on :8080/:8081/:1313 and otherwise spawns `dev_stage`
+(`dev-server.mjs:56`). Checking `prod_prod`, the environment that actually deploys, currently
+means starting a server by hand and exporting `DE_BASE_URL`.
+
+The check itself needs no new flag: `site-characterization.mjs:1015` derives the baseline key
+from the running site (`env.hugoEnv === "prod_prod" ? "prod_prod" : env.dataBranch`). So the whole
+feature is "start the right server and point the harness at it" — which
+`site-characterization-rebaseline.mjs:187-228` already does correctly, for `--baseline`.
+
+## Decisions taken
+
+- **A dedicated npm script per environment, plus one generic script taking a positional.** Not
+  `--env prod_prod` and not `--prod_prod`. Measured 2026-08-26, npm 11.4.1 under PowerShell, with
+  a throwaway package printing `process.argv` and `npm_config_*`:
+
+  | Invocation | Script sees |
+  |---|---|
+  | `npm run show --prod_prod` | `argv: []`, `npm_config_prod_prod=true` |
+  | `npm run show --env prod_prod` | `argv: ["prod_prod"]`, `npm_config_env=true` |
+  | `npm run show -- --env prod_prod` | identical — PowerShell ate the `--` |
+  | `npm run show local_prod` | `argv: ["local_prod"]` |
+  | `npm run show local_prod extra` | `argv: ["local_prod","extra"]` |
+  | `npm run show local_prod --concurrency 8` | `argv: ["local_prod","8"]` |
+
+  Bare positionals survive npm untouched; any `--flag` has its NAME eaten and its value left as a
+  nameless positional. Hence: environments as positionals, and the wrapper REJECTS any argument
+  starting with `--` rather than let `8` be read as an environment name. Flags stay available
+  through a direct `node scripts/site-characterization.mjs` call.
+
+- **Extract the server lifecycle rather than export it from `rebaseline.mjs`.** The shared piece
+  is the isolation logic whose failure mode is corrupting a running server's `resources/_gen`; it
+  should have one home, not a home and an importer.
+
+- **Do NOT converge `.github/workflows/site-characterization.yml` onto the new wrapper.** Rejected
+  deliberately. CI's server wait is clock-bounded (`$SECONDS` against a 300s deadline,
+  `--max-time 120` per attempt, `kill -0 $HUGO_PID` to tell "still building" from "Hugo died",
+  `tail hugo-server.log` on failure), tuned for a cold runner with no EHDP-data cache — one `curl`
+  blocked 61s inside a single iteration on run 32771116783. Converging makes a local convenience
+  script load-bearing for the deploy gate and trades a diagnosable failure for a generic timeout.
+
+- **CI is out of scope and must stay that way.** It calls `node scripts/site-characterization.mjs`
+  directly (`site-characterization.yml:240`, `:423`), never an npm script, and passes
+  `DE_BASE_URL`, which takes `ensureDevServer`'s path 1 and never reaches the spawn logic. Nothing
+  CI runs imports `rebaseline.mjs`. **The constraint that keeps this true: do not touch
+  `dev-server.mjs`** — it IS imported by `site-characterization.mjs`, `smoke-pages.mjs`, and
+  `site-characterization-probe-control.mjs`.
+
+## Environment-to-key mapping
+
+Derived by the harness, not by the wrapper. Only `staging` and `prod_prod` are committed, so the
+rest exit 2 with the "No baseline" message at `site-characterization.mjs:1075-1092`.
+
+| Environment | Key | Baseline committed? |
+|---|---|---|
+| `prod_prod` | `prod_prod` | yes |
+| `dev_stage`, `local_stage`, `prod_stage` | `staging` | yes |
+| `dev_prod`, `development`, `local_prod`, `production` | `production` | no |
+
+## Tasks
+
+| # | Task | Commit | Status | Proof that ran |
+|---|---|---|---|---|
+| 1 | Extract `startServer` / `makeStop` / `responds` / `ENVIRONMENT_FOR` from `site-characterization-rebaseline.mjs` into a new `scripts/isolated-server.mjs`; import them back | `feature-characterize-env @ d14ab4e841` | **DONE 2026-08-26** | Reverse-transform: rebuilt the pre-move file from the two current ones, undoing only the declared normalizations (5 `export` prefixes, `sc-rebaseline`->`sc-isolated`, the import lines, one comment pointer). `diff` against the pre-move snapshot exits 0, byte-identical, 629 lines both sides. Plus `node --check` on both files; `import()` of the module lists exactly `ENVIRONMENT_FOR, ISO_ROOT, PORT, responds, startServer`; a symbol sweep shows `spawn`/`tmpdir`/`sleep`/`HUGO_BIN`/`PREFIXES`/`makeStop`/`SERVER_TIMEOUT_S` now at 0 occurrences in rebaseline and non-zero in the module; `--help` runs clean through the new import. The extracted `startServer` was also exercised for real, unintentionally — see the incident below |
+| 2 | New `scripts/characterize-env.mjs <environment> [positional concurrency?]` — validate the name against `config/`, reject `--` args, start server, build Pagefind into its isolated `destDir`, run `site-characterization.mjs --check --all` as a child with `DE_BASE_URL` + `DE_SERVER_OWNED=1`, stop in `finally` | | Not started | *planned:* `--help`-style rejection cases run by hand; full run is task 5 |
+| 3 | `package.json`: `characterize:site:env`, `characterize:site:prod_prod`, `characterize:site:dev_stage` | | Not started | *planned:* `npm run characterize:site:env` with no argument exits non-zero naming the valid environments |
+| 4 | Document the split: comment block in `characterize-env.mjs` and a CLAUDE.md line saying how `characterize:site:dev_stage` (isolated, private :8090 server, never reuses) differs from `characterize:site` (reuses whatever is up, builds into `docs/`) | | Not started | *planned:* prose diffed against the actual script bodies |
+| 5 | End-to-end: `npm run characterize:site:prod_prod` against this tree | | Not started | *planned:* exit 0 against the committed `prod_prod` baseline; `docs/` and `resources/_gen` unchanged afterward (path+size+mtime manifest before and after) |
+
+## Incident 2026-08-26: an unintended re-baseline
+
+`node scripts/site-characterization-rebaseline.mjs nosuchkey` was run as what was believed to be
+an unknown-key error path. **That script takes no positional arguments at all** — `main()` sets
+`keys = committedKeys()`, read from disk, and unrecognized argv is silently ignored. So the
+invocation was the bare, destructive one: it began re-capturing BOTH committed baselines.
+
+Killed after ~2 minutes, mid-sweep of `prod_prod`. Restored with the script's own documented pair,
+`git checkout -- scripts/site-characterization-baseline` then `git clean -fd` on the same path.
+Verified: `git status --porcelain` on that path is silent, both keys hold 926 files, and
+`capturedAt` reads the original `2026-08-25T19:22:10.988Z` / `19:28:12.257Z`. `scripts/.sc-rebaseline`
+removed; no `hugo.exe` survives and :8090 is free.
+
+Two things it did establish, before it was killed: the extracted `startServer` works — it brought up
+an isolated `prod_prod` server on :8090 serving `/IndicatorPublic/`, with `HUGO_RESOURCEDIR` and
+`-d` under `C:/Users/Chris/AppData/Local/Temp/sc-isolated/` — and the harness then selected the
+`prod_prod` baseline unaided and enumerated 925 pages.
+
+**Open, not actioned:** `site-characterization-rebaseline.mjs` ignores unrecognized arguments and
+proceeds to overwrite every committed baseline. Rejecting unknown argv would have made this a
+one-line error. Out of scope for this branch unless asked.
+
+## Environment state
+
+- Branch `feature-characterize-env`, cut from local `production` at `3d5438830c`. No upstream set.
+- No Hugo server running at branch time (`Get-NetTCPConnection -LocalPort 8080,8081,1313` returned
+  nothing; no `hugo.exe`).
+- Task 5 spawns a private server on :8090 and writes an isolated build under the temp root
+  `rebaseline.mjs:87` defines. If a run is interrupted, check for a surviving `hugo.exe` on :8090.
+
+## Next command
+
+```
+git -C . rev-parse --abbrev-ref HEAD     # expect feature-characterize-env
+git log --oneline 3d5438830c..HEAD       # the task commits; empty means task 1 has not landed
+```
+
+Then start task 1 by reading `scripts/site-characterization-rebaseline.mjs` lines 140-230.

--- a/documents/characterize-env-plan-2026-08-26.md
+++ b/documents/characterize-env-plan-2026-08-26.md
@@ -1,9 +1,16 @@
 # Per-environment characterization invocation
 
-**Status as of 2026-08-26: branch `feature-characterize-env` cut from `production` at
-`3d5438830c`; tasks 1-6 done at `d14ab4e841` and `4a91dd94f9`, task 7 (human-facing docs) and the
-diagnosis of the `prod_prod` diff done and uncommitted. The diff is a live-data marker count, not
-a regression — nothing to fix in this repo, but the `img` field is unstable on any map page.**
+**Status as of 2026-08-26: DONE. Branch `feature-characterize-env`, cut from `production` at
+`3d5438830c`, five commits `d14ab4e841..8c15d56ae7`, unpushed. `npm run
+characterize:site:prod_prod` passes 925/925 at `8c15d56ae7`.**
+
+Derive what a status line cannot hold:
+
+```
+git log --oneline 3d5438830c..HEAD                          # the five task commits
+git rev-list --left-right --count origin/production...HEAD  # right-hand number = unpushed
+gh pr list --head feature-characterize-env                  # a PR, and against which base
+```
 
 ## Why
 
@@ -143,6 +150,112 @@ deliberately still count — that exclusion was written for tile *timing*, and d
 marker set whose size is data-driven. Such a page goes red whenever the feed moves, with no
 code change. Worth deciding separately from this branch: exclude marker icons too, or accept
 periodic re-baselines.
+
+## Task 8: stop counting map markers (in progress)
+
+Direction from the user 2026-08-26: a marker count tracks monitor uptime, which is transient —
+check for markers *at all* instead, and do not re-baseline for a down monitor.
+
+Evidence the design rests on `[verified 2026-08-26 in a browser, isolated prod_prod server, three
+page kinds]`: a marker `<img>` carries **no class of its own** — `div.leaflet-marker-icon` is its
+PARENT — which is why `classList.contains("leaflet-marker-icon")` reads false and only `closest`
+finds them. `el.closest(".leaflet-container")` separates cleanly: 25 of 30 images in-map on
+`realtime-air-quality`, 9 of 14 on `neighborhood-reports/bayside_little_neck/` (all tiles, no
+markers), 0 of 5 on `data-explorer/asthma/`.
+
+Split in two so the count change is provable apart from the field addition, which by construction
+touches all 925 records in both keys:
+
+**Step 1 — widen the filter from `.leaflet-tile` to `.leaflet-container`.** Predictions, written
+before the run:
+
+1. Exit 1.
+2. `data-features/realtime-air-quality/`: `img.total` 19 -> 3, `img.missingAlt` 16 -> 0.
+3. NR pages do NOT move — their only in-map images are tiles, already excluded.
+4. No field outside `structure.img.*` changes.
+5. Unknown, and the reason this sweep is worth its five minutes: whether
+   `data-features/proximity/` (131 images) and `data-features/congestion-pricing-report/` (115)
+   carry in-map images. Both read `missingAlt` 0, so neither is alt-less markers, but nothing
+   yet says what they are.
+
+**Step 1 result: four of five predictions confirmed exactly; the fifth was the finding.**
+Exit 1, four pages, two fields, nothing outside `structure.img.*`, and no NR page moved.
+`realtime-air-quality` went 19 -> 3 and `missingAlt` 16 -> 0, as predicted. What the sweep bought
+was prediction 5: `data-features/proximity/` 131 -> 3 and
+`data-features/congestion-pricing-report/` 115 -> 4 **both carry in-map images** — 128 and 111 of
+them — and `data-features/heat-story/` 22 -> 3 carries 19. Three pages nobody had looked at were
+recording map contents as page structure. Log at `C:/temp/characterize-step1.log`.
+
+**A cost I flagged, then retired.** The worry was that those 128 and 111 in-map images might be
+static page content the check would stop watching. They are not: the control shows all of them are
+`map-pin-hollow_P.svg` marker icons — 128 on `proximity`, 111 on `congestion-pricing-report`, 19 on
+`heat-story` — the same category as air-quality's 15 `map-marker.svg`. All four are marker sets
+drawn from data, differing only in how fast their data moves. Excluding them loses no static
+imagery. What remains true, and is the real trade: a map that loses *some* markers but not all now
+passes, because presence is all that is recorded.
+
+**Step 2 — add `img.mapMarkers`**, a boolean: did the map draw any markers at all. Queried as
+`.leaflet-marker-icon` directly rather than through the images, so a marker drawn without an
+`<img>` still counts. **Positive control passed, both directions** `[2026-08-26, six pages, isolated prod_prod server]`:
+
+| Page | `.leaflet-marker-icon` | `mapMarkers` |
+|---|---|---|
+| `data-features/proximity/` | 128 | `true` |
+| `data-features/congestion-pricing-report/` | 111 | `true` |
+| `data-features/heat-story/` | 19 | `true` |
+| `data-features/realtime-air-quality/` | 15 | `true` |
+| `neighborhood-reports/bayside_little_neck/` | 0 | `false` |
+| `data-explorer/asthma/` | 0 | `false` |
+
+So the selector is not dead, and `false` is not its only reading. The two `false` rows are the
+arm that matters — a map with tiles and no markers, and a page with no map — since a selector
+matching nothing would produce them too, and only the `true` rows rule that out. Marker counts
+reconcile against the baseline arithmetic on all four: 128 + 3 chrome = 131, 111 + 4 = 115,
+19 + 3 = 22, 15 + 3 = 18/19.
+
+**Step 2b — key the exclusion by page** (user direction 2026-08-26, replacing the global form).
+Only `realtime-air-quality` reads a live feed; `proximity`, `congestion-pricing-report` and
+`heat-story` draw markers from data that changes by hand, so on those pages a marker appearing or
+vanishing IS the regression the check exists to catch, and their counts stay. This also retires
+`mapMarkers` as a global field: where counts are kept, a marker set dropping to zero already shows
+as a count diff, so the flag is recorded only where the count was suppressed.
+
+Keyed on the record's own `path`, derived inside `CAPTURE` from `location.pathname` and `prefix`
+using the same stripping idiom as `:321`, so neither caller's one-argument signature changes.
+
+Predictions before the run:
+
+1. Exit 1.
+2. **Exactly one page** differs: `data-features/realtime-air-quality/`.
+3. On it: `img.total` 19 -> 3, `img.missingAlt` 16 -> 0, plus a new `mapMarkers: true`.
+4. `proximity`, `congestion-pricing-report` and `heat-story` do **not** move — this is the
+   control on the keying. If they move, the page match failed open.
+5. No other page gains `mapMarkers`.
+
+A wrong prefix match would make `liveMarkers` false everywhere, leaving the page at 19 and the run
+green at 0 pages — so the run discriminates the failure mode rather than merely passing.
+
+**Result: all five confirmed** `[2026-08-26, C:/temp/characterize-step2b.log]`. `1 of 925 page(s)
+differ, across 3 field(s)`, all on `data-features/realtime-air-quality/`: `total` 19 -> 3,
+`missingAlt` 16 -> 0, `mapMarkers` undefined -> true. `proximity`, `congestion-pricing-report` and
+`heat-story` kept their 131, 115 and 22 — the keying scoped rather than failing open.
+
+**Step 3 — re-baselined both keys, at the user's go-ahead.** `node
+scripts/site-characterization-rebaseline.mjs --expect "data-features/realtime-air-quality/"`:
+1 of 925 pages changed in each key, 1 covered by `--expect`, 0 not, **"Nothing unexplained"** on
+both, `"arbitrated": []` on both. The EHDP-data drift this was watched for did not materialize.
+
+Working tree matched the report exactly: four files, the two records carrying `19 -> 3`,
+`16 -> 0`, `+mapMarkers: true` and nothing else, plus the two `_meta.json` — which also gained
+`dataCommit`, `arbitrated`, `cleared` and `capped`, fields the harness grew after 2026-08-25, so
+their absence was the stale half rather than anything this change did. Provenance now records
+production data at `c03ccd89fb` (2026-08-26) and staging at `b2b63d0635` (2026-08-17).
+
+**Then the check itself was re-run, which is a different claim from "the capture succeeded":**
+`npm run characterize:site:prod_prod` -> `Characterization check PASSED`, 925/925 pages, every one
+reaching DOM quiescence before the cap, exit 0.
+
+All of task 8 is at `8c15d56ae7`.
 
 ## Environment state
 

--- a/documents/characterize-env-plan-2026-08-26.md
+++ b/documents/characterize-env-plan-2026-08-26.md
@@ -1,7 +1,9 @@
 # Per-environment characterization invocation
 
 **Status as of 2026-08-26: branch `feature-characterize-env` cut from `production` at
-`3d5438830c`; task 1 done at `d14ab4e841`, tasks 2-5 not started.**
+`3d5438830c`; tasks 1-6 done at `d14ab4e841` and `4a91dd94f9`. The tooling works. One page
+differs on `prod_prod` that this branch did not cause, and it REPRODUCES exactly — open, and
+awaiting a decision (investigate / re-baseline / leave).**
 
 ## Why
 
@@ -69,10 +71,11 @@ rest exit 2 with the "No baseline" message at `site-characterization.mjs:1075-10
 | # | Task | Commit | Status | Proof that ran |
 |---|---|---|---|---|
 | 1 | Extract `startServer` / `makeStop` / `responds` / `ENVIRONMENT_FOR` from `site-characterization-rebaseline.mjs` into a new `scripts/isolated-server.mjs`; import them back | `feature-characterize-env @ d14ab4e841` | **DONE 2026-08-26** | Reverse-transform: rebuilt the pre-move file from the two current ones, undoing only the declared normalizations (5 `export` prefixes, `sc-rebaseline`->`sc-isolated`, the import lines, one comment pointer). `diff` against the pre-move snapshot exits 0, byte-identical, 629 lines both sides. Plus `node --check` on both files; `import()` of the module lists exactly `ENVIRONMENT_FOR, ISO_ROOT, PORT, responds, startServer`; a symbol sweep shows `spawn`/`tmpdir`/`sleep`/`HUGO_BIN`/`PREFIXES`/`makeStop`/`SERVER_TIMEOUT_S` now at 0 occurrences in rebaseline and non-zero in the module; `--help` runs clean through the new import. The extracted `startServer` was also exercised for real, unintentionally — see the incident below |
-| 2 | New `scripts/characterize-env.mjs <environment> [positional concurrency?]` — validate the name against `config/`, reject `--` args, start server, build Pagefind into its isolated `destDir`, run `site-characterization.mjs --check --all` as a child with `DE_BASE_URL` + `DE_SERVER_OWNED=1`, stop in `finally` | | Not started | *planned:* `--help`-style rejection cases run by hand; full run is task 5 |
-| 3 | `package.json`: `characterize:site:env`, `characterize:site:prod_prod`, `characterize:site:dev_stage` | | Not started | *planned:* `npm run characterize:site:env` with no argument exits non-zero naming the valid environments |
-| 4 | Document the split: comment block in `characterize-env.mjs` and a CLAUDE.md line saying how `characterize:site:dev_stage` (isolated, private :8090 server, never reuses) differs from `characterize:site` (reuses whatever is up, builds into `docs/`) | | Not started | *planned:* prose diffed against the actual script bodies |
-| 5 | End-to-end: `npm run characterize:site:prod_prod` against this tree | | Not started | *planned:* exit 0 against the committed `prod_prod` baseline; `docs/` and `resources/_gen` unchanged afterward (path+size+mtime manifest before and after) |
+| 2 | New `scripts/characterize-env.mjs <environment>` — validate the name against `config/`, reject `-` args, start server, build Pagefind into its isolated `destDir`, run `site-characterization.mjs --check --all` as a child with `DE_BASE_URL` + `DE_SERVER_OWNED=1`, stop in `finally` | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** | Five rejection paths, exit code read from `$LASTEXITCODE` on its own line rather than after a pipeline (a pipe returns the pager's status): no argument, `local_prod --concurrency 8` (arrives as two positionals), unknown environment, a `-` flag, two environments — **all exit 2** with a specific message. Concurrency pass-through was dropped: not asked for, and the harness's machine-derived default is better than a number chosen here |
+| 3 | `package.json`: `characterize:site:env`, `characterize:site:prod_prod`, `characterize:site:dev_stage` | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** | 3-line diff, hand formatting intact — edited as a string replace, not a `json.load`/`dump` round trip, which would have reformatted the whole file. `npm run characterize:site:env` with no argument exits 2 listing the eight environments |
+| 4 | Document the split: comment block in `characterize-env.mjs` and a CLAUDE.md line saying how `characterize:site:dev_stage` (isolated, private :8090 server, never reuses) differs from `characterize:site` (reuses whatever is up, builds into `docs/`) | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** | Two CLAUDE.md bullets and the four new command lines; the argument bullet carries the measured npm table rather than asserting the behaviour |
+| 5 | End-to-end: `npm run characterize:site:prod_prod` against this tree | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** — with a caveat, see below | The wrapper worked: server up, `prod_prod` baseline selected unaided, 925 pages swept, server stopped, harness exit code (1) passed through. **Isolation proven:** `resources/_gen` 399 files and `docs/` 2934 files byte-identical on a path+size+mtime manifest before and after. The exit 1 is a real site diff, not a wrapper fault — see below. Log at `C:/temp/characterize-prod_prod.log` |
+| 6 | Fold in the hazard the incident exposed: make `rebaseline.mjs` refuse unrecognized arguments instead of ignoring them | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** | `parseArgs` rewritten as one consuming pass returning `unknown`; `main` exits 2 on any leftover and points at `characterize-env.mjs`. The exact command from the incident, `rebaseline.mjs nosuchkey`, now exits 2 without touching a baseline — as do `--nosuchflag` and a dangling `--expect` (previously dropped in silence). Positive control the other way: `--report-only --expect "data-explorer/*" --concurrency 8` still parses and runs, echoing the glob as claimed-intended, exit 0, `git status` on the baseline path silent afterwards |
 
 ## Incident 2026-08-26: an unintended re-baseline
 
@@ -92,9 +95,39 @@ an isolated `prod_prod` server on :8090 serving `/IndicatorPublic/`, with `HUGO_
 `-d` under `C:/Users/Chris/AppData/Local/Temp/sc-isolated/` — and the harness then selected the
 `prod_prod` baseline unaided and enumerated 925 pages.
 
-**Open, not actioned:** `site-characterization-rebaseline.mjs` ignores unrecognized arguments and
-proceeds to overwrite every committed baseline. Rejecting unknown argv would have made this a
-one-line error. Out of scope for this branch unless asked.
+**Actioned as task 6**, at the user's direction 2026-08-26 — this branch is where the argument
+handling is being written, so the fix belongs with it rather than in a follow-up.
+
+## Open: one page differs on `prod_prod`, and this branch did not cause it
+
+`data-features/realtime-air-quality/` — `structure.img.total` 19 -> 18 and
+`structure.img.missingAlt` 16 -> 15, against the `prod_prod` baseline captured at `e93bfcf1d5`
+(2026-08-25). One `<img>` fewer, and the one that went had no `alt`.
+
+Established:
+
+- **Not caused by this branch.** `git diff --name-only production..HEAD -- themes assets config
+  data content static` is empty, and so is the same diff against the working tree.
+- **Not a Leaflet base tile.** `site-characterization.mjs:398` filters `.leaflet-tile` out of the
+  `img` set, and the comment above it records why (four loads of one NR page gave `img.total`
+  17, 17, 20, 20 purely from tile timing). Marker icons and anything else inside the map still
+  count — the comment says so explicitly.
+- The page draws a live map: `content/data-features/realtime-air-quality/js/realtime.js:462` adds
+  a carto CDN tile layer, and the page's data is realtime air quality.
+
+**It reproduces exactly.** A second `npm run characterize:site:prod_prod`, ~20 minutes after the
+first, gave the identical page, the identical two fields and the identical numbers (19 -> 18,
+16 -> 15). So this is a stable difference between the site as it renders now and the baseline
+captured 2026-08-25, not a capture flake.
+
+**Still not established: which `<img>` went.** The record stores counts only, and `assets` cannot
+narrow it — `assetNodes` (`site-characterization.mjs:329`) covers `script[src]` and
+`link[rel=stylesheet][href]` alone, so images were never in that field and its being unchanged
+means nothing here. Answering it needs the page loaded and its non-tile `<img>` set dumped.
+
+**Consequence while it stands:** `npm run characterize:site:prod_prod` exits 1 for everyone. Three
+ways out, and the choice is the user's: find and fix the cause; re-capture the `prod_prod` baseline
+if the change is intended; or leave it recorded here as a known red.
 
 ## Environment state
 

--- a/documents/characterize-env-plan-2026-08-26.md
+++ b/documents/characterize-env-plan-2026-08-26.md
@@ -1,8 +1,9 @@
 # Per-environment characterization invocation
 
-**Status as of 2026-08-26: DONE. Branch `feature-characterize-env`, cut from `production` at
-`3d5438830c`, five commits `d14ab4e841..8c15d56ae7`, unpushed. `npm run
-characterize:site:prod_prod` passes 925/925 at `8c15d56ae7`.**
+**Status as of 2026-08-26: tasks 1-8 DONE, `d14ab4e841..8c15d56ae7` on branch
+`feature-characterize-env`, cut from `production` at `3d5438830c`. `npm run
+characterize:site:prod_prod` passes 925/925 at `8c15d56ae7`. Task 9 — the `sample` positional,
+added to match `feature-smoke-env`'s `smoke-env.mjs` — is DONE at `e92c7ac15c`.**
 
 Derive what a status line cannot hold:
 
@@ -83,6 +84,7 @@ rest exit 2 with the "No baseline" message at `site-characterization.mjs:1075-10
 | 4 | Document the split: comment block in `characterize-env.mjs` and a CLAUDE.md line saying how `characterize:site:dev_stage` (isolated, private :8090 server, never reuses) differs from `characterize:site` (reuses whatever is up, builds into `docs/`) | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** | Two CLAUDE.md bullets and the four new command lines; the argument bullet carries the measured npm table rather than asserting the behaviour |
 | 5 | End-to-end: `npm run characterize:site:prod_prod` against this tree | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** — with a caveat, see below | The wrapper worked: server up, `prod_prod` baseline selected unaided, 925 pages swept, server stopped, harness exit code (1) passed through. **Isolation proven:** `resources/_gen` 399 files and `docs/` 2934 files byte-identical on a path+size+mtime manifest before and after. The exit 1 is a real site diff, not a wrapper fault — see below. Log at `C:/temp/characterize-prod_prod.log` |
 | 6 | Fold in the hazard the incident exposed: make `rebaseline.mjs` refuse unrecognized arguments instead of ignoring them | `feature-characterize-env @ 4a91dd94f9` | **DONE 2026-08-26** | `parseArgs` rewritten as one consuming pass returning `unknown`; `main` exits 2 on any leftover and points at `characterize-env.mjs`. The exact command from the incident, `rebaseline.mjs nosuchkey`, now exits 2 without touching a baseline — as do `--nosuchflag` and a dangling `--expect` (previously dropped in silence). Positive control the other way: `--report-only --expect "data-explorer/*" --concurrency 8` still parses and runs, echoing the glob as claimed-intended, exit 0, `git status` on the baseline path silent afterwards |
+| 9 | Optional second positional `sample` on `characterize-env.mjs`, so the curated 41-page check can run against a NAMED environment; one argument contract with `feature-smoke-env`'s `smoke-env.mjs`. Plus `readme-development.md` and `CLAUDE.md` | `feature-characterize-env @ e92c7ac15c` | **DONE 2026-08-26** | Five rejection arms, each exit 2 with its own message: no argument, unknown environment, `--env prod_prod`, `prod_prod typo`, three positionals. The `typo` arm is the load-bearing one — without the explicit `SAMPLE` comparison it would have swept all 925 pages silently. End-to-end: `npm run characterize:site:prod_prod sample` -> **PASSED, exit 0**, 41/41 captured, every page quiescent before the cap, `prod_prod` baseline selected unaided, log at `C:/temp/characterize-sample.log`. That run also proves `sample` survives npm + PowerShell as a positional, and answers the open question about partial captures: the 884 uncompared pages are NOT reported as deletions — sample mode projects both sides through the intersection (`site-characterization.mjs:1345-1364`) |
 
 ## Incident 2026-08-26: an unintended re-baseline
 
@@ -259,7 +261,8 @@ All of task 8 is at `8c15d56ae7`.
 
 ## Environment state
 
-- Branch `feature-characterize-env`, cut from local `production` at `3d5438830c`. No upstream set.
+- Branch `feature-characterize-env`, cut from local `production` at `3d5438830c`. Upstream is
+  now `refs/heads/feature-characterize-env` — its own name, not `production`.
 - No Hugo server running at branch time (`Get-NetTCPConnection -LocalPort 8080,8081,1313` returned
   nothing; no `hugo.exe`).
 - Task 5 spawns a private server on :8090 and writes an isolated build under the temp root
@@ -269,7 +272,19 @@ All of task 8 is at `8c15d56ae7`.
 
 ```
 git -C . rev-parse --abbrev-ref HEAD     # expect feature-characterize-env
-git log --oneline 3d5438830c..HEAD       # the task commits; empty means task 1 has not landed
+git log --oneline 3d5438830c..HEAD       # the task commits
+git branch -a --contains e92c7ac15c      # where task 9 has reached since
 ```
 
-Then start task 1 by reading `scripts/site-characterization-rebaseline.mjs` lines 140-230.
+All nine tasks have landed. Nothing is queued; the branch is ready for a PR into `production`.
+
+To re-run task 9's end-to-end proof from scratch: `npm run characterize:site:prod_prod sample`,
+expect `Characterization check PASSED`, exit 0, 41/41 pages, and one named uncompared page
+(`data-explorer/asthma/?id=2380` — no baseline record exists for a query string, in either
+baseline; `find scripts/site-characterization-baseline -name '*id=2380*'` returns nothing).
+
+`feature-smoke-env` carries the same `sample` contract on `smoke-env.mjs` and has already edited
+`readme-development.md`'s command table and its "Checking a specific environment" block. The two
+branches will conflict in that file. **Take both sides** — the edits are the smoke row and the
+characterization row of the same table, and the smoke lines and characterization lines of the same
+code block.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
         "characterize:cp": "node scripts/cp-characterization.mjs",
         "characterize:site": "node scripts/site-characterization.mjs --check --all",
         "characterize:site:sample": "node scripts/site-characterization.mjs --check",
+        "characterize:site:env": "node scripts/characterize-env.mjs",
+        "characterize:site:prod_prod": "node scripts/characterize-env.mjs prod_prod",
+        "characterize:site:dev_stage": "node scripts/characterize-env.mjs dev_stage",
         "characterize:site:baseline": "node scripts/site-characterization.mjs --baseline --all",
         "characterize:site:rebaseline": "node scripts/site-characterization-rebaseline.mjs",
         "docs-check": "node scripts/docs-check.mjs"

--- a/readme-development.md
+++ b/readme-development.md
@@ -139,6 +139,14 @@ is a starting point, not a verdict — a page can move because the data behind i
 third-party embed rendered differently, not only because someone broke it. Read what changed before
 assuming a regression.
 
+Some pages legitimately go red when *data* changes rather than code. `data-features/proximity/`,
+`data-features/congestion-pricing-report/` and `data-features/heat-story/` draw a map marker per
+row of their data, and the check counts those markers on purpose — a marker appearing or vanishing
+is a real change to what the page shows. Editing that data therefore means re-capturing the
+baselines, and that is working as intended, not a bug. `data-features/realtime-air-quality/` is the
+exception: its markers come from a live feed that nobody here controls, so its marker count is
+deliberately **not** recorded — only whether the map drew any markers at all.
+
 If a site-wide change is *intended*, the baselines are re-captured with
 `npm run characterize:site:rebaseline`, which rebuilds every committed baseline and reports what
 moved. That command takes no arguments and overwrites all of them, so it is not the way to check a

--- a/readme-development.md
+++ b/readme-development.md
@@ -82,6 +82,68 @@ Current environments:
 
 **A note on `production` vs `prod_prod`:** the two config files are byte-identical, but the environment *name* is what `partials/head.html` branches on. Only `prod_prod` gets the production Google Analytics property and omits the `<meta name="robots" content="noindex, nofollow">` tag; every other environment — including `production`, and including a bare `hugo` with no `--environment` flag — emits the noindex tag and the development analytics property. The build workflow uses `hugo --environment prod_prod`, so the live site is correct. Build locally with `prod_prod` if you are inspecting anything that depends on those tags.
 
+### Checking your work
+
+Two automated checks live in this repo. Both need `npm install` first, and both drive a real
+browser, so they catch things a successful `hugo` build does not — a build only proves the
+templates compile.
+
+| Command | What it does |
+|---|---|
+| `npm run smoke` | Loads 33 pages, one per template kind, and fails on any JavaScript error. Fast. |
+| `npm run smoke:all` | The same, over every page the site serves. For a pre-merge sweep. |
+| `npm run characterize:site` | Loads every page and compares its *structure* — assets, heading levels, `alt` text, tables, JSON-LD, overflow — against a committed baseline. |
+| `npm run characterize:site:sample` | The same check over 41 pages, one per template kind. |
+
+Run `smoke` before merging anything that touches `partials/head.html`, `_default/baseof.html`, the
+header or footer partials, or `assets/js/`. Neither check sees what the other does: `smoke` catches
+JavaScript that throws, characterization catches a page whose markup quietly moved.
+
+#### Checking a specific environment
+
+`npm run characterize:site` checks whichever environment your machine happens to be serving — it
+reuses any Hugo server already answering on :8080, :8081 or :1313, and otherwise starts `dev_stage`
+for you. When you need a *named* environment instead, and especially `prod_prod`, which is the one
+that actually deploys:
+
+```bash
+npm run characterize:site:prod_prod        # the environment the live site is built with
+npm run characterize:site:dev_stage        # staging data, deterministically
+npm run characterize:site:env local_prod   # any environment in config/
+```
+
+These start their own Hugo server on port 8090, build it entirely outside the repo, and stop it
+when they finish — so they ignore whatever you have running, and they leave `docs/` and
+`resources/_gen` untouched. They are slower than `characterize:site`, because a full build runs
+before the check does.
+
+Two baselines are committed, between them covering four of the eight environments. The rest
+stop and say which baselines exist:
+
+| Environment | Baseline used |
+|---|---|
+| `prod_prod` | `prod_prod` |
+| `dev_stage`, `local_stage`, `prod_stage` | `staging` |
+| `dev_prod`, `development`, `local_prod`, `production` | **none — the check exits and tells you so** |
+
+**Pass the environment as a plain word, not as a flag.** `npm run characterize:site:env prod_prod`
+works; `npm run characterize:site:env --env prod_prod` does not, because PowerShell and npm between
+them discard the flag's name and keep only its value. The scripts refuse anything starting with `-`
+rather than act on a mangled argument. If you need the underlying flags, call the script directly:
+`node scripts/site-characterization.mjs --check --content`.
+
+#### When a check fails
+
+A characterization failure names each page and field that moved, with the raw diff underneath. That
+is a starting point, not a verdict — a page can move because the data behind it moved, or because a
+third-party embed rendered differently, not only because someone broke it. Read what changed before
+assuming a regression.
+
+If a site-wide change is *intended*, the baselines are re-captured with
+`npm run characterize:site:rebaseline`, which rebuilds every committed baseline and reports what
+moved. That command takes no arguments and overwrites all of them, so it is not the way to check a
+single environment — the `characterize:site:env` scripts above are.
+
 ### Data repository
 
 Most of the data used by the site is stored in the separate [EHDP-data](https://github.com/nychealth/EHDP-data) repository. This setup allows us to update the site's data without needing to re-build the entire site. Look there for descriptions of the data files, and for the code used to generate the them. 

--- a/readme-development.md
+++ b/readme-development.md
@@ -94,6 +94,7 @@ templates compile.
 | `npm run smoke:all` | The same, over every page the site serves. For a pre-merge sweep. |
 | `npm run characterize:site` | Loads every page and compares its *structure* — assets, heading levels, `alt` text, tables, JSON-LD, overflow — against a committed baseline. |
 | `npm run characterize:site:sample` | The same check over 41 pages, one per template kind. |
+| `npm run characterize:site:env <env> [sample]` | The same check, against a named environment it builds and serves itself. |
 
 Run `smoke` before merging anything that touches `partials/head.html`, `_default/baseof.html`, the
 header or footer partials, or `assets/js/`. Neither check sees what the other does: `smoke` catches
@@ -110,7 +111,12 @@ that actually deploys:
 npm run characterize:site:prod_prod        # the environment the live site is built with
 npm run characterize:site:dev_stage        # staging data, deterministically
 npm run characterize:site:env local_prod   # any environment in config/
+npm run characterize:site:env local_prod sample   # the curated 41 pages instead of all of them
 ```
+
+Add the word `sample` to check the curated one-page-per-template list rather than the whole site.
+A full Hugo build runs either way, so `sample` narrows *what* gets checked rather than making the
+command quick.
 
 These start their own Hugo server on port 8090, build it entirely outside the repo, and stop it
 when they finish — so they ignore whatever you have running, and they leave `docs/` and

--- a/scripts/characterize-env.mjs
+++ b/scripts/characterize-env.mjs
@@ -1,7 +1,9 @@
 // Run the characterization check against ONE named Hugo environment.
 //
-//   node scripts/characterize-env.mjs prod_prod
+//   node scripts/characterize-env.mjs prod_prod            every page the site serves
+//   node scripts/characterize-env.mjs prod_prod sample     the curated one-per-template list
 //   npm run characterize:site:prod_prod
+//   npm run characterize:site:env local_prod sample
 //
 // The check itself needs no new flag: site-characterization.mjs derives the
 // baseline key from the running site (prod_prod by environment name, otherwise
@@ -21,6 +23,12 @@
 //                            with both writable outputs redirected outside the
 //                            repo, and stops it afterwards. Deterministic, and
 //                            it leaves docs/ and resources/_gen untouched.
+//
+// The page set is the whole site by default and the curated 41-page list with
+// `sample`, matching `characterize:site` and `characterize:site:sample`. Note
+// that a cold Hugo build and a Pagefind build run either way, so `sample` saves
+// the sweep and not the build — it narrows WHAT is checked, not how long the
+// command takes.
 //
 // Arguments are POSITIONAL on purpose. Measured 2026-08-26 (npm 11.4.1,
 // PowerShell): `npm run x -- --env prod_prod` reaches the script as
@@ -45,11 +53,21 @@ const environments = () => readdirSync(`${REPO_ROOT}/config`, { withFileTypes: t
     .map((e) => e.name)
     .sort();
 
+// The optional second positional. A bare word rather than a flag, for the same
+// reason the environment is: `npm run x local_prod extra` reaches the script as
+// argv ["local_prod","extra"] — positionals survive npm and PowerShell intact
+// where a `--flag` does not. Spelled out rather than accepted loosely, so a typo
+// stops the run instead of silently sweeping every page when 41 were wanted.
+const SAMPLE = "sample";
+
 const usage = (message) => {
     console.error(`${message}\n`);
-    console.error("  node scripts/characterize-env.mjs <environment>");
-    console.error("  npm run characterize:site:env <environment>\n");
+    console.error("  node scripts/characterize-env.mjs <environment> [sample]");
+    console.error("  npm run characterize:site:env <environment> [sample]\n");
     console.error(`Environments: ${environments().join(", ")}\n`);
+    console.error("Checks every page the site serves, like `npm run characterize:site`. Add the");
+    console.error(`word \`${SAMPLE}\` for the curated one-page-per-template list instead, like`);
+    console.error("`npm run characterize:site:sample`.\n");
     console.error("Only `staging` (dev_stage, local_stage, prod_stage) and `prod_prod` have a");
     console.error("committed baseline; the rest exit 2 saying so. Flags are not accepted here —");
     console.error("npm and PowerShell mangle them; use node scripts/site-characterization.mjs.");
@@ -62,10 +80,16 @@ async function main() {
 
     const flag = args.find((a) => a.startsWith("-"));
     if (flag) usage(`This script takes no flags, and "${flag}" would not have survived npm intact.`);
-    if (args.length !== 1) usage(args.length ? `Expected one environment, got ${args.length}.` : "No environment given.");
+    if (args.length < 1) usage("No environment given.");
+    if (args.length > 2) usage(`Expected an environment and optionally "${SAMPLE}", got ${args.length} arguments.`);
 
-    const environment = args[0];
+    const [environment, mode] = args;
     if (!environments().includes(environment)) usage(`No config/${environment}/ in this repo.`);
+    if (mode !== undefined && mode !== SAMPLE) usage(`Second argument must be "${SAMPLE}" or absent, not "${mode}".`);
+
+    // Full site unless asked otherwise. --all is what makes site-characterization.mjs
+    // sweep every page; without it, it reads its curated sample list.
+    const sweepArgs = mode === SAMPLE ? ["--check"] : ["--check", "--all"];
 
     // Same guard the re-baseline tool keeps: :8090 is this port precisely
     // because nothing else probes it, so anything answering there is either a
@@ -93,7 +117,7 @@ async function main() {
         // calls process.exit. DE_SERVER_OWNED tells dev-server.mjs we spawned
         // this server ourselves, so the run records the Hugo version as this
         // server's rather than as the one the checkout would have used.
-        execFileSync(process.execPath, ["scripts/site-characterization.mjs", "--check", "--all"], {
+        execFileSync(process.execPath, ["scripts/site-characterization.mjs", ...sweepArgs], {
             cwd: REPO_ROOT,
             stdio: "inherit",
             env: { ...process.env, DE_BASE_URL: baseURL, DE_SERVER_OWNED: "1" },

--- a/scripts/characterize-env.mjs
+++ b/scripts/characterize-env.mjs
@@ -1,0 +1,111 @@
+// Run the characterization check against ONE named Hugo environment.
+//
+//   node scripts/characterize-env.mjs prod_prod
+//   npm run characterize:site:prod_prod
+//
+// The check itself needs no new flag: site-characterization.mjs derives the
+// baseline key from the running site (prod_prod by environment name, otherwise
+// by data branch). So the whole job here is starting the right server and
+// pointing the harness at it — which is what isolated-server.mjs does, and what
+// site-characterization-rebaseline.mjs already did for --baseline.
+//
+// HOW THIS DIFFERS FROM `npm run characterize:site`, which also ends in a
+// --check and is the one to reach for by default:
+//
+//   characterize:site        resolves a server through dev-server.mjs: reuses
+//                            whatever answers on :8080/:8081/:1313, and failing
+//                            that spawns dev_stage and builds into the repo's
+//                            own docs/ and resources/_gen. So WHICH environment
+//                            it checks depends on what you have running.
+//   characterize:site:env X  ignores every running server, spawns X on :8090
+//                            with both writable outputs redirected outside the
+//                            repo, and stops it afterwards. Deterministic, and
+//                            it leaves docs/ and resources/_gen untouched.
+//
+// Arguments are POSITIONAL on purpose. Measured 2026-08-26 (npm 11.4.1,
+// PowerShell): `npm run x -- --env prod_prod` reaches the script as
+// argv ["prod_prod"] — PowerShell eats the `--` and npm eats the flag NAME,
+// leaving its value as a nameless positional. A bare positional survives both
+// intact. So a `--flag` here is never what the caller thinks it is, and is
+// rejected rather than half-honoured; flags remain available by calling
+// site-characterization.mjs directly.
+
+import { execFileSync, execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ISO_ROOT, PORT, responds, startServer } from "./isolated-server.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+// Every environment config/ actually holds. Read from disk rather than listed
+// here, so adding an environment needs no edit in this file — and so a typo is
+// caught before a cold Hugo build, not after one.
+const environments = () => readdirSync(`${REPO_ROOT}/config`, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && e.name !== "_default")
+    .map((e) => e.name)
+    .sort();
+
+const usage = (message) => {
+    console.error(`${message}\n`);
+    console.error("  node scripts/characterize-env.mjs <environment>");
+    console.error("  npm run characterize:site:env <environment>\n");
+    console.error(`Environments: ${environments().join(", ")}\n`);
+    console.error("Only `staging` (dev_stage, local_stage, prod_stage) and `prod_prod` have a");
+    console.error("committed baseline; the rest exit 2 saying so. Flags are not accepted here —");
+    console.error("npm and PowerShell mangle them; use node scripts/site-characterization.mjs.");
+    process.exit(2);
+};
+
+async function main() {
+
+    const args = process.argv.slice(2);
+
+    const flag = args.find((a) => a.startsWith("-"));
+    if (flag) usage(`This script takes no flags, and "${flag}" would not have survived npm intact.`);
+    if (args.length !== 1) usage(args.length ? `Expected one environment, got ${args.length}.` : "No environment given.");
+
+    const environment = args[0];
+    if (!environments().includes(environment)) usage(`No config/${environment}/ in this repo.`);
+
+    // Same guard the re-baseline tool keeps: :8090 is this port precisely
+    // because nothing else probes it, so anything answering there is either a
+    // sibling run or a server a previous run failed to reap.
+    if (await responds(`http://localhost:${PORT}/`)) {
+        console.error(`Something is already answering on :${PORT}. This script needs that port `
+            + `for its own server. If a previous run was interrupted, look for a surviving hugo.`);
+        process.exit(2);
+    }
+
+    console.log(`Isolated build under ${ISO_ROOT}`);
+    const { baseURL, destDir, stop } = await startServer(environment);
+    console.log(`  serving ${baseURL}`);
+
+    try {
+        // Not optional. The harness refuses to compare a searched site against
+        // a search-less baseline, and both committed baselines carry the index
+        // — so without this every run would exit 2 on the pagefind mismatch.
+        // Same command the deploy workflow runs.
+        console.log("  building the Pagefind index");
+        execSync(`npx -y pagefind --site "${destDir}"`, { cwd: REPO_ROOT, stdio: "ignore" });
+
+        // Driven as a child rather than imported, for the reason rebaseline.mjs
+        // gives: site-characterization.mjs is a CLI that reads process.argv and
+        // calls process.exit. DE_SERVER_OWNED tells dev-server.mjs we spawned
+        // this server ourselves, so the run records the Hugo version as this
+        // server's rather than as the one the checkout would have used.
+        execFileSync(process.execPath, ["scripts/site-characterization.mjs", "--check", "--all"], {
+            cwd: REPO_ROOT,
+            stdio: "inherit",
+            env: { ...process.env, DE_BASE_URL: baseURL, DE_SERVER_OWNED: "1" },
+        });
+    } catch (e) {
+        // The harness's own output above says what moved. Its exit code is the
+        // verdict and is passed straight through: 1 regressions, 2 could not run.
+        process.exitCode = typeof e.status === "number" ? e.status : 1;
+    } finally {
+        stop();
+        console.log(`  stopped the ${environment} server`);
+    }
+}
+
+main();

--- a/scripts/isolated-server.mjs
+++ b/scripts/isolated-server.mjs
@@ -1,0 +1,131 @@
+// An isolated `hugo server` for one environment: a private port, and both
+// writable outputs redirected outside the repo.
+//
+// Extracted from site-characterization-rebaseline.mjs so that the two callers
+// that need a server for a NAMED environment — the re-baseline tool and
+// characterize-env.mjs — share one implementation. The thing being shared is
+// the isolation, whose failure mode is corrupting a running server's
+// fingerprint cache, so it gets one home rather than a home and a copy.
+//
+// Deliberately NOT part of dev-server.mjs, which answers a different question:
+// "what server should the harness use", including reusing one it finds and
+// building into the repo's own docs/. This module never reuses and never
+// touches the repo's outputs. dev-server.mjs is imported by the harness, the
+// smoke test and the probe control, so it is left alone.
+
+import { spawn, execSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { SPAWN_CMD as HUGO_BIN, PREFIXES } from "./dev-server.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+// Which Hugo environment produces each baseline key. The key is a property of
+// the OUTPUT (data branch, plus prod_prod's environment-name branch in
+// head.html); this maps back to one environment that produces it. Any
+// environment in a key's row would do — these are just the ones the committed
+// baselines were captured from.
+export const ENVIRONMENT_FOR = {
+    staging: "dev_stage",
+    production: "dev_prod",
+    prod_prod: "prod_prod",
+};
+
+// Deliberately OFF dev-server.mjs's probe list (8080, 8081, 1313). On a probed
+// port, any other harness invocation running at the same time would discover
+// this script's private server and sweep the wrong environment against the
+// wrong baseline.
+export const PORT = 8090;
+
+// Where the isolated servers write. Outside the repo, so neither resources/_gen
+// nor docs/ is reachable from them — that is the whole isolation claim.
+export const ISO_ROOT = `${tmpdir().replace(/\\/g, "/")}/sc-isolated`;
+
+// A build of this site takes ~34s on this machine, plus Hugo's own startup.
+const SERVER_TIMEOUT_S = 200;
+
+// Kill a spawned server and everything under it. child.kill() does not reap
+// descendants on Windows, which is how a "stopped" server keeps serving.
+//
+// Idempotent via its own flag rather than via child.killed, which taskkill
+// never sets: this is called once from recapture's finally block and again from
+// the process exit handler, and a second taskkill would be aimed at a PID the
+// OS is free to have reassigned by then.
+const makeStop = (child) => {
+    let stopped = false;
+    return () => {
+        if (!child || stopped) return;
+        stopped = true;
+        if (process.platform === "win32") {
+            try { execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: "ignore" }); } catch { /* already gone */ }
+        } else {
+            child.kill("SIGTERM");
+        }
+    };
+};
+
+export const responds = async (url) => {
+    try {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 3000);
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(t);
+        return res.status === 200;
+    } catch {
+        return false;
+    }
+};
+
+// Start an isolated server for one environment and return its base URL.
+//
+// Both redirections are load-bearing and neither is optional: -d keeps the
+// build out of docs/, HUGO_RESOURCEDIR keeps it out of resources/_gen, and
+// resources/_gen is the one that corrupts a running server's asset paths.
+//
+// The prefix is PROBED rather than read from config/, because the served prefix
+// is whatever that environment's baseURL says and probing cannot disagree with
+// the running server.
+export const startServer = async (environment) => {
+
+    const destDir = `${ISO_ROOT}/${environment}-docs`;
+    const resourceDir = `${ISO_ROOT}/${environment}-resources`;
+    rmSync(destDir, { recursive: true, force: true });
+    rmSync(resourceDir, { recursive: true, force: true });
+
+    const args = ["server", "--environment", environment, "--cleanDestinationDir",
+        "--disableFastRender", "-p", String(PORT), "-d", destDir];
+
+    console.log(`  starting isolated ${environment} server on :${PORT}`);
+    console.log(`    HUGO_RESOURCEDIR=${resourceDir}`);
+    console.log(`    -d ${destDir}`);
+
+    // Shell mode on Windows because hugo only resolves through PATHEXT there,
+    // and as one pre-joined string because an args array with shell:true trips
+    // Node's DEP0190 warning. Quoting therefore happens at the one point where
+    // the array has to become a string — a resolved binary path or a temp
+    // directory can hold a space, which an args array never has to care about.
+    const quote = (a) => (/\s/.test(a) ? `"${a}"` : a);
+    const spawnEnv = { ...process.env, HUGO_RESOURCEDIR: resourceDir };
+    const child = process.platform === "win32"
+        ? spawn([HUGO_BIN, ...args].map(quote).join(" "),
+            { cwd: REPO_ROOT, shell: true, stdio: "ignore", env: spawnEnv })
+        : spawn(HUGO_BIN, args, { cwd: REPO_ROOT, stdio: "ignore", env: spawnEnv });
+
+    const stop = makeStop(child);
+    process.once("exit", stop);
+    process.once("SIGINT", () => { stop(); process.exit(130); });
+
+    for (let i = 0; i < SERVER_TIMEOUT_S; i++) {
+        for (const prefix of PREFIXES) {
+            const baseURL = `http://localhost:${PORT}${prefix}`;
+            if (await responds(baseURL)) return { baseURL, destDir, stop };
+        }
+        await sleep(1000);
+    }
+
+    stop();
+    throw new Error(`The ${environment} server did not answer on :${PORT} within ${SERVER_TIMEOUT_S}s.`);
+};
+

--- a/scripts/site-characterization-baseline/prod_prod/_meta.json
+++ b/scripts/site-characterization-baseline/prod_prod/_meta.json
@@ -1,9 +1,14 @@
 {
-    "capturedAt": "2026-08-25T19:22:10.988Z",
-    "gitHead": "e93bfcf1d5a4d3d8fdac2021a047ddcc60765580",
+    "capturedAt": "2026-08-26T16:39:43.494Z",
+    "gitHead": "4715de67e4ed1c76d923533b8a29c9aaff163043",
     "baselineKey": "prod_prod",
     "hugoEnv": "prod_prod",
     "dataBranch": "production",
+    "dataCommit": {
+        "sha": "c03ccd89fb167fff2416902645d63a5b3b3c61bb",
+        "date": "2026-08-26T16:00:05Z",
+        "fetchedAt": "2026-08-26T16:35:59.971Z"
+    },
     "pagefind": true,
     "hugo": {
         "version": "0.147.3-05417512bd001c0b2cc0042dcc584575825b89b3+extended",
@@ -12,6 +17,9 @@
     "prefix": "/IndicatorPublic/",
     "mode": "all",
     "pages": 925,
+    "arbitrated": [],
+    "cleared": [],
+    "capped": false,
     "viewport": {
         "width": 1280,
         "height": 900

--- a/scripts/site-characterization-baseline/prod_prod/data-features/realtime-air-quality/index.json
+++ b/scripts/site-characterization-baseline/prod_prod/data-features/realtime-air-quality/index.json
@@ -82,10 +82,11 @@
             }
         ],
         "img": {
-            "total": 19,
-            "missingAlt": 16,
+            "total": 3,
+            "missingAlt": 0,
             "emptyAlt": 0,
-            "zeroSize": 0
+            "zeroSize": 0,
+            "mapMarkers": true
         },
         "links": {
             "internal": 91,

--- a/scripts/site-characterization-baseline/staging/_meta.json
+++ b/scripts/site-characterization-baseline/staging/_meta.json
@@ -1,9 +1,14 @@
 {
-    "capturedAt": "2026-08-25T19:28:12.257Z",
-    "gitHead": "e93bfcf1d5a4d3d8fdac2021a047ddcc60765580",
+    "capturedAt": "2026-08-26T16:44:10.181Z",
+    "gitHead": "4715de67e4ed1c76d923533b8a29c9aaff163043",
     "baselineKey": "staging",
     "hugoEnv": "dev_stage",
     "dataBranch": "staging",
+    "dataCommit": {
+        "sha": "b2b63d0635516187debcc95ad2347e97cf502993",
+        "date": "2026-08-17T18:33:22Z",
+        "fetchedAt": "2026-08-26T16:40:29.207Z"
+    },
     "pagefind": true,
     "hugo": {
         "version": "0.147.3-05417512bd001c0b2cc0042dcc584575825b89b3+extended",
@@ -12,6 +17,9 @@
     "prefix": "/dev-stage/",
     "mode": "all",
     "pages": 925,
+    "arbitrated": [],
+    "cleared": [],
+    "capped": false,
     "viewport": {
         "width": 1280,
         "height": 900

--- a/scripts/site-characterization-baseline/staging/data-features/realtime-air-quality/index.json
+++ b/scripts/site-characterization-baseline/staging/data-features/realtime-air-quality/index.json
@@ -82,10 +82,11 @@
             }
         ],
         "img": {
-            "total": 19,
-            "missingAlt": 16,
+            "total": 3,
+            "missingAlt": 0,
             "emptyAlt": 0,
-            "zeroSize": 0
+            "zeroSize": 0,
+            "mapMarkers": true
         },
         "links": {
             "internal": 91,

--- a/scripts/site-characterization-rebaseline.mjs
+++ b/scripts/site-characterization-rebaseline.mjs
@@ -37,13 +37,11 @@
 // Exit codes: 0 nothing unexplained; 1 unexplained changes to review; 2 the run
 // could not be made at all.
 
-import { spawn, execFileSync, execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { summarize, renderText } from "./site-characterization-summary.mjs";
-import { SPAWN_CMD as HUGO_BIN, PREFIXES } from "./dev-server.mjs";
+import { ENVIRONMENT_FOR, ISO_ROOT, PORT, responds, startServer } from "./isolated-server.mjs";
 
 // ----------------------------------------------------------------------- //
 // configuration
@@ -64,30 +62,6 @@ const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 // printed. `[observed 2026-08-25: a capture left one untracked record; checkout
 // alone reported the tree clean while `git status` still showed `??`]`
 const DISCARD = [`git checkout -- ${BASELINE_ROOT}`, `git clean -fd ${BASELINE_ROOT}`];
-
-// Which Hugo environment produces each baseline key. The key is a property of
-// the OUTPUT (data branch, plus prod_prod's environment-name branch in
-// head.html); this maps back to one environment that produces it. Any
-// environment in a key's row would do — these are just the ones the committed
-// baselines were captured from.
-const ENVIRONMENT_FOR = {
-    staging: "dev_stage",
-    production: "dev_prod",
-    prod_prod: "prod_prod",
-};
-
-// Deliberately OFF dev-server.mjs's probe list (8080, 8081, 1313). On a probed
-// port, any other harness invocation running at the same time would discover
-// this script's private server and sweep the wrong environment against the
-// wrong baseline.
-const PORT = 8090;
-
-// Where the isolated servers write. Outside the repo, so neither resources/_gen
-// nor docs/ is reachable from them — that is the whole isolation claim.
-const ISO_ROOT = `${tmpdir().replace(/\\/g, "/")}/sc-rebaseline`;
-
-// A build of this site takes ~34s on this machine, plus Hugo's own startup.
-const SERVER_TIMEOUT_S = 200;
 
 // How much of a dirty `git status` the preflight prints before summarizing.
 const DIRTY_LINES = 12;
@@ -137,93 +111,6 @@ const globToRegExp = (glob) => {
     const escaped = glob.replace(/[.+^${}()|[\]\\?]/g, "\\$&");
     const body = escaped.replace(/\*\*/g, "\u0000").replace(/\*/g, "[^/]*").replace(/\u0000/g, ".*");
     return new RegExp(`^${body}$`);
-};
-
-// ----------------------------------------------------------------------- //
-// server lifecycle
-// ----------------------------------------------------------------------- //
-
-// Kill a spawned server and everything under it. child.kill() does not reap
-// descendants on Windows, which is how a "stopped" server keeps serving.
-//
-// Idempotent via its own flag rather than via child.killed, which taskkill
-// never sets: this is called once from recapture's finally block and again from
-// the process exit handler, and a second taskkill would be aimed at a PID the
-// OS is free to have reassigned by then.
-const makeStop = (child) => {
-    let stopped = false;
-    return () => {
-        if (!child || stopped) return;
-        stopped = true;
-        if (process.platform === "win32") {
-            try { execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: "ignore" }); } catch { /* already gone */ }
-        } else {
-            child.kill("SIGTERM");
-        }
-    };
-};
-
-const responds = async (url) => {
-    try {
-        const controller = new AbortController();
-        const t = setTimeout(() => controller.abort(), 3000);
-        const res = await fetch(url, { signal: controller.signal });
-        clearTimeout(t);
-        return res.status === 200;
-    } catch {
-        return false;
-    }
-};
-
-// Start an isolated server for one environment and return its base URL.
-//
-// Both redirections are load-bearing and neither is optional: -d keeps the
-// build out of docs/, HUGO_RESOURCEDIR keeps it out of resources/_gen, and
-// resources/_gen is the one that corrupts a running server's asset paths.
-//
-// The prefix is PROBED rather than read from config/, because the served prefix
-// is whatever that environment's baseURL says and probing cannot disagree with
-// the running server.
-const startServer = async (environment) => {
-
-    const destDir = `${ISO_ROOT}/${environment}-docs`;
-    const resourceDir = `${ISO_ROOT}/${environment}-resources`;
-    rmSync(destDir, { recursive: true, force: true });
-    rmSync(resourceDir, { recursive: true, force: true });
-
-    const args = ["server", "--environment", environment, "--cleanDestinationDir",
-        "--disableFastRender", "-p", String(PORT), "-d", destDir];
-
-    console.log(`  starting isolated ${environment} server on :${PORT}`);
-    console.log(`    HUGO_RESOURCEDIR=${resourceDir}`);
-    console.log(`    -d ${destDir}`);
-
-    // Shell mode on Windows because hugo only resolves through PATHEXT there,
-    // and as one pre-joined string because an args array with shell:true trips
-    // Node's DEP0190 warning. Quoting therefore happens at the one point where
-    // the array has to become a string — a resolved binary path or a temp
-    // directory can hold a space, which an args array never has to care about.
-    const quote = (a) => (/\s/.test(a) ? `"${a}"` : a);
-    const spawnEnv = { ...process.env, HUGO_RESOURCEDIR: resourceDir };
-    const child = process.platform === "win32"
-        ? spawn([HUGO_BIN, ...args].map(quote).join(" "),
-            { cwd: REPO_ROOT, shell: true, stdio: "ignore", env: spawnEnv })
-        : spawn(HUGO_BIN, args, { cwd: REPO_ROOT, stdio: "ignore", env: spawnEnv });
-
-    const stop = makeStop(child);
-    process.once("exit", stop);
-    process.once("SIGINT", () => { stop(); process.exit(130); });
-
-    for (let i = 0; i < SERVER_TIMEOUT_S; i++) {
-        for (const prefix of PREFIXES) {
-            const baseURL = `http://localhost:${PORT}${prefix}`;
-            if (await responds(baseURL)) return { baseURL, destDir, stop };
-        }
-        await sleep(1000);
-    }
-
-    stop();
-    throw new Error(`The ${environment} server did not answer on :${PORT} within ${SERVER_TIMEOUT_S}s.`);
 };
 
 // ----------------------------------------------------------------------- //
@@ -487,7 +374,7 @@ async function main() {
     const unknown = keys.filter((k) => !ENVIRONMENT_FOR[k]);
     if (unknown.length && !reportOnly) {
         console.error(`No environment mapped for baseline key(s): ${unknown.join(", ")}.\n`
-            + `Add them to ENVIRONMENT_FOR in this file.`);
+            + `Add them to ENVIRONMENT_FOR in scripts/isolated-server.mjs.`);
         process.exit(2);
     }
 

--- a/scripts/site-characterization-rebaseline.mjs
+++ b/scripts/site-characterization-rebaseline.mjs
@@ -306,27 +306,37 @@ const classify = (key, globs) => {
 // main
 // ----------------------------------------------------------------------- //
 
+// One pass that CONSUMES every argument, so anything left over is unrecognized
+// and can be refused. The refusal is the point: this script takes no positional
+// arguments — it re-captures every committed baseline, always — and an argument
+// it merely ignored was indistinguishable from the bare, destructive
+// invocation. `[2026-08-26: `rebaseline.mjs nosuchkey`, run in the belief that
+// it named one key, silently began re-capturing both]`
 const parseArgs = (argv) => {
     const expect = [];
+    const unknown = [];
+    let concurrency = null;
+    let reportOnly = false;
+    let help = false;
+
     for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
         // Presence, not truthiness: the home page's `path` is the EMPTY STRING,
         // so `--expect ""` is the only way to claim it and a falsy check would
         // drop it silently.
-        if (argv[i] === "--expect" && i + 1 < argv.length) expect.push(argv[++i]);
-    }
-    const at = (flag) => {
-        const i = argv.indexOf(flag);
-        return i !== -1 && argv[i + 1] ? argv[i + 1] : null;
-    };
-    return {
-        expect,
+        if (arg === "--expect" && i + 1 < argv.length) expect.push(argv[++i]);
         // Passed straight through to the harness, which owns the default. Null
         // here means "say nothing", so the harness's machine-derived value
         // stands rather than being overridden by a number chosen in this file.
-        concurrency: Number(at("--concurrency")) || null,
-        reportOnly: argv.includes("--report-only"),
-        help: argv.includes("--help") || argv.includes("-h"),
-    };
+        else if (arg === "--concurrency" && i + 1 < argv.length) concurrency = Number(argv[++i]) || null;
+        else if (arg === "--report-only") reportOnly = true;
+        else if (arg === "--help" || arg === "-h") help = true;
+        // Catches a value-taking flag given last with nothing after it, too:
+        // `--expect` alone lands here rather than being dropped in silence.
+        else unknown.push(arg);
+    }
+
+    return { expect, concurrency, reportOnly, help, unknown };
 };
 
 const USAGE = `Re-capture every committed characterization baseline after a deliberate site change.
@@ -357,11 +367,25 @@ const committedKeys = () => {
 
 async function main() {
 
-    const { expect, reportOnly, help, concurrency } = parseArgs(process.argv.slice(2));
+    const { expect, reportOnly, help, concurrency, unknown: unknownArgs } = parseArgs(process.argv.slice(2));
 
     if (help) {
         console.log(USAGE);
         return;
+    }
+
+    // Refuse rather than ignore. Every run of this script overwrites every
+    // committed baseline, so "the argument I passed did nothing" and "I ran the
+    // destructive form" have to look different from each other.
+    if (unknownArgs.length) {
+        console.error(`Unrecognized argument(s): ${unknownArgs.map((a) => `"${a}"`).join(", ")}.
+`);
+        console.error(`This script takes no positional arguments — it re-captures EVERY committed`);
+        console.error(`baseline. To check ONE environment without re-capturing anything, use`);
+        console.error(`  node scripts/characterize-env.mjs <environment>
+`);
+        console.error(USAGE);
+        process.exit(2);
     }
 
     const keys = committedKeys();

--- a/scripts/site-characterization.mjs
+++ b/scripts/site-characterization.mjs
@@ -387,21 +387,62 @@ export const CAPTURE = (prefix) => {
     // Counted over the parsed DOM rather than over source lines: a line-oriented
     // sweep scores the opening line of a multi-line <img> as missing its alt.
     //
-    // Leaflet map tiles are excluded, and that exclusion is load-bearing. How
-    // many tiles a map has fetched is a fact about network timing, not about
-    // the page: four loads of one neighborhood report gave img.total 17, 17,
-    // 20, 20, and img.leaflet-tile 9, 9, 12, 12 — while the images *outside*
-    // the map container were 8 on all four [verified 2026-08-23 in a browser].
-    // Left in, this field alone failed the first full-site --check on 9 NR
-    // pages. Only `.leaflet-tile` goes; marker icons and anything else inside
-    // the map are still counted, because those are page structure.
-    const imgs = $$("img").filter((el) => !el.classList.contains("leaflet-tile"));
+    // Leaflet map tiles are excluded on every page, and that exclusion is
+    // load-bearing. How many tiles a map has fetched is a fact about network
+    // timing, not about the page: four loads of one neighborhood report gave
+    // img.total 17, 17, 20, 20 and img.leaflet-tile 9, 9, 12, 12, while the
+    // images *outside* the map container were 8 on all four [verified
+    // 2026-08-23 in a browser]. Left in, this field alone failed the first
+    // full-site --check on 9 NR pages.
+    //
+    // Marker icons are excluded on ONE page, and the narrowness is the point.
+    // A marker count is worth keeping wherever the markers come from data that
+    // changes by hand: there, markers appearing or vanishing is exactly the
+    // regression this check exists to catch. `proximity` (128 markers),
+    // `congestion-pricing-report` (111) and `heat-story` (19) are all in that
+    // class and keep their counts. `realtime-air-quality` is not: it draws one
+    // marker per LIVE air-quality monitor, so a monitor going down moves
+    // img.total and img.missingAlt with no code change — which reddened a
+    // prod_prod --check twice on 2026-08-26, 19 -> 18 and 16 -> 15, purely
+    // from the feed.
+    //
+    // A marker image carries no class of its own; the class sits on its PARENT
+    // div.leaflet-marker-icon, so `classList.contains` never matches one and
+    // only `closest` does `[verified 2026-08-26 in a browser: 15
+    // map-marker.svg, every one parented by div.leaflet-marker-icon, and the
+    // only alt-less images on that page]`.
+    //
+    // Derived from location rather than passed in, so both callers of CAPTURE
+    // keep their one-argument signature. Same prefix-stripping as the asset
+    // and link paths below, so the entry matches a record's own `path` field.
+    const LIVE_MARKER_PAGES = ["data-features/realtime-air-quality/"];
+    const herePath = location.pathname.startsWith(prefix)
+        ? location.pathname.slice(prefix.length)
+        : location.pathname.replace(/^\//, "");
+    const liveMarkers = LIVE_MARKER_PAGES.includes(herePath);
+
+    const imgs = $$("img").filter((el) => (liveMarkers
+        ? !el.closest(".leaflet-container")
+        : !el.classList.contains("leaflet-tile")));
 
     const img = {
         total: imgs.length,
         missingAlt: imgs.filter((el) => !el.hasAttribute("alt")).length,
         emptyAlt: imgs.filter((el) => el.getAttribute("alt") === "").length,
         zeroSize: imgs.filter(isZeroSized).length,
+
+        // Recorded only where the count was suppressed, because only there is
+        // it carrying anything: on a page that still counts its markers, a
+        // marker set dropping to zero already shows up as a count diff, and a
+        // second field saying so would be a field added to 925 records to
+        // restate what one of them already says.
+        //
+        // Presence, not count: how MANY markers the map drew tracks the feed,
+        // but whether it drew any at all is a fact about the page, and catches
+        // the failure that matters — tiles rendering with no data on them.
+        // Queried on `.leaflet-marker-icon` directly rather than through the
+        // images, so a marker drawn as a divIcon with no <img> still registers.
+        ...(liveMarkers ? { mapMarkers: $$(".leaflet-marker-icon").length > 0 } : {}),
     };
 
     // --- links -----------------------------------------------------------


### PR DESCRIPTION
## What this adds

`npm run characterize:site` can only check whichever environment `scripts/dev-server.mjs` happens to resolve — it reuses any server answering on :8080/:8081/:1313 and otherwise spawns `dev_stage`. Checking `prod_prod`, the environment that actually deploys, meant starting a server by hand and exporting `DE_BASE_URL`.

```
npm run characterize:site:prod_prod          # isolated prod_prod server on :8090, all 925 pages
npm run characterize:site:dev_stage
npm run characterize:site:env local_prod
npm run characterize:site:prod_prod sample   # the 41-page, one-per-template-kind check
```

`scripts/characterize-env.mjs` ignores running servers entirely: spawns the named environment on :8090 with `-d` and `HUGO_RESOURCEDIR` redirected outside the repo, builds Pagefind into that isolated `publishDir`, runs `--check --all` against it, and stops it in a `finally`. `docs/` and `resources/_gen` are untouched — proven on a path+size+mtime manifest, 399 files and 2934 files byte-identical before and after.

`scripts/isolated-server.mjs` is that lifecycle extracted from `site-characterization-rebaseline.mjs`, which now imports it. Pure relocation, proven by reverse-transform: rebuilding the pre-move file from the two current ones exits `diff` 0, byte-identical, 629 lines both sides.

## Arguments are positional, deliberately

Measured 2026-08-26, npm 11.4.1 under PowerShell: `npm run x --env prod_prod` reaches the script as `argv ["prod_prod"]` — PowerShell eats the `--` and npm eats the flag *name*, leaving its value as a nameless positional, so `--concurrency 8` arrives as a bare `"8"`. Bare positionals survive both intact. The wrapper therefore rejects any argument starting with `-` rather than half-honour it; flags stay available through a direct `node scripts/site-characterization.mjs` call. Five rejection arms, each exiting 2 with its own message.

Same reasoning made `site-characterization-rebaseline.mjs` refuse unrecognized arguments outright. It takes none and re-captures *every* committed baseline on every run, so an argument it merely ignored made a typo indistinguishable from the destructive invocation — which is how `rebaseline.mjs nosuchkey`, believed to name one key, began re-capturing both. `--report-only --expect "..." --concurrency 8` still parses and runs (positive control, exit 0).

## Map markers stopped being counted on one page

`structure.img.total` and `structure.img.missingAlt` were counting Leaflet marker icons. On `data-features/realtime-air-quality/` the markers are one per live air-quality monitor, so the page went red whenever the feed moved, with no code change.

Four pages draw markers from data; only that one reads a live feed. The exclusion is keyed on the record's own path so `proximity`, `congestion-pricing-report` and `heat-story` keep their counts — a marker appearing or vanishing there IS the regression the check exists to catch. Suppressing all four would have dropped 239 markers out of the check. Where the count is suppressed, a new `img.mapMarkers` boolean records that the map drew markers at all.

Positive control, six pages, both directions: 128/111/19/15 markers → `true`; a map with tiles and no markers, and a page with no map → `false`.

## Baselines re-captured

`rebaseline.mjs --expect "data-features/realtime-air-quality/"`: 1 of 925 pages changed in each key, 1 covered by `--expect`, 0 not, "Nothing unexplained" and `"arbitrated": []` on both. The two `_meta.json` also gained `dataCommit`, `arbitrated`, `cleared` and `capped` — fields the harness grew after the 2026-08-25 capture.

## Verification

- `npm run characterize:site:prod_prod` at `8c15d56ae7` → **PASSED**, 925/925, exit 0.
- `npm run characterize:site:prod_prod sample` at `e92c7ac15c` → **PASSED**, 41/41, exit 0.
- `e92c7ac15c..HEAD` touches only `documents/characterize-env-plan-2026-08-26.md`, so both proofs still hold at the tip.

CI is out of scope and stays that way: `.github/workflows/site-characterization.yml` calls `node scripts/site-characterization.mjs` directly and passes `DE_BASE_URL`, never reaching the spawn logic. `dev-server.mjs` is deliberately untouched — it is imported by three scripts.

## Note for whoever merges next

`feature-smoke-env` carries the same `sample` positional contract on `smoke-env.mjs` and edits the same `readme-development.md` table and code block. It will conflict there once this lands. **Take both sides** — the edits are the smoke rows and the characterization rows of the same table.

Full ledger, including the five-prediction runs and the incident: [documents/characterize-env-plan-2026-08-26.md](documents/characterize-env-plan-2026-08-26.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
