### PR TITLE
Select the environment for a smoke run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,14 +45,31 @@ Local site: http://localhost:1313/EH-dataportal
 ```bash
 npm run smoke                                          # 33 pages, one per template kind
 npm run smoke:all                                      # every page the site serves
+npm run smoke:prod_prod                                # every page, on an isolated prod_prod server
+npm run smoke:env local_prod                           # every page, on any environment in config/
+npm run smoke:env local_prod sample                    # the curated 33 instead, same isolated server
 DE_BASE_URL="http://localhost:1313/dev-prod/" npm run smoke   # against a server you already have
 ```
 
-`scripts/smoke-pages.mjs` loads pages under Playwright and fails on any console `error` or `pageerror` that isn't allowlisted. It is the only automated check in the repo, and it exists because a `hugo` build proves the templates compile and nothing more: the site's browser JS is classic `<script>` tags sharing one global scope, so a bad edit throws at load while the build stays green. **Run it before merging anything that touches `head.html`, `baseof.html`, the header/footer partials, or `assets/js/`.**
+`scripts/smoke-pages.mjs` loads pages under Playwright and fails on any console `error` or `pageerror` that isn't allowlisted. It is the only check here that runs the site's JavaScript, and it exists because a `hugo` build proves the templates compile and nothing more: the site's browser JS is classic `<script>` tags sharing one global scope, so a bad edit throws at load while the build stays green. **Run it before merging anything that touches `head.html`, `baseof.html`, the header/footer partials, or `assets/js/`.**
 
 The default reads the curated `PAGES` list — one page per template kind, weighted toward templates that load map and chart libraries, which is what a quick check wants. `smoke:all` reads the whole site instead, for a pre-merge or pre-deploy sweep.
 
-Seven things to know before trusting a result:
+`smoke:env <environment>` (`scripts/smoke-env.mjs`) is `smoke:all` against an environment you name
+rather than one you happen to be serving. It is the second caller of `scripts/isolated-server.mjs`
+— `characterize-env.mjs` is the first — so the isolation is theirs in common: :8090, `-d` and
+`HUGO_RESOURCEDIR` both outside the repo, server stopped afterwards. Two axes make the environment
+worth naming: `head.html` branches on the environment *name*, and each environment pins its own
+`data_branch`, which changes the EHDP-data URLs a page fetches **at runtime** — a renamed data file
+throws in the browser on one environment and not another. Same positional-argument contract as
+`characterize-env.mjs`, `--flag` rejected, for the reason measured there. An optional second
+positional, the bare word `sample`, swaps the full sweep for the curated `PAGES` list — spelled out
+exactly, so a typo exits 2 rather than quietly sweeping 925 pages when 33 were wanted. A cold Hugo
+build runs either way, so `sample` narrows what is checked and does not make the command quick. The
+two `:env` scripts share :8090 and so cannot run concurrently; each refuses to start when the other
+holds it.
+
+Eight things to know before trusting a result:
 
 - **`npm run smoke -- --all` does not work here.** PowerShell eats the `--`, so the script gets an empty `argv` and silently runs the curated list — a pass you would read as full coverage. That is why `--all` has its own npm script. Direct `node scripts/smoke-pages.mjs --all --concurrency 12` works from either shell.
 - **Before citing the *curated* run as proof for a change that only executes on one page kind, check that page is in `PAGES`.** The comments there name the template that renders each URL, and a comment naming the wrong one is how a page ends up with no coverage while looking covered. `smoke:all` removes this concern and is the answer when you can afford the wall time.
@@ -62,7 +79,20 @@ Seven things to know before trusting a result:
   `ABSENT` before it sweeps. Blanket-allowlisting it was masking `PagefindUI is not defined` on
   every page `[2026-08-24: with the predicate forced off and no index, smoke failed 33 of 33]`.
 - **`smoke:all` enumerates rather than hardcodes, and prints the breakdown every run** (`scripts/site-urls.mjs`): `sitemap.xml` for content pages in all three languages, plus a probe walk for paginator pages, plus `404.html`. Hugo lists neither of the last two in any sitemap, and reports only a *count* for paginator pages — which is the cross-check. `[verified 2026-08-22 on feature-audit-moderate against a development-environment server: 925 pages = 830 sitemap + 94 paginator + 1, enumerated in 0.5s, and the 94 matched Hugo's build summary exactly; reproduced 2026-08-23 on `production` against a dev_stage server, same 830/94/1 breakdown]`. That total is the same set as the 927 counted below over a `prod_prod` build; only the paginator count differs between branches.
-- **Concurrent failures are re-checked sequentially before being reported.** A sweep that reports a concurrency artefact as a regression gets ignored, so pages that clear on the re-run are printed separately and do not fail the run `[2026-08-22: 925 pages in 449s at the default concurrency of 6; zero cleared on re-check]`. **The mechanism is not established.** The explanation that used to sit in `smoke-pages.mjs`, and in this bullet — pages contending for one `hugo server`'s on-demand render — was never measured, and does not hold up: measured 2026-08-23 at concurrency 6 against 1 over 12 pages, navigation slowed 1.34x, JS settle time was 1.00x, and all 12 reached identical final DOM states — nowhere near enough to time a page out. Treat the re-check as a guard for an unexplained flake, not a fix for a known cause.
+- **Concurrent failures are re-checked sequentially before being reported.** A sweep that reports a concurrency artefact as a regression gets ignored, so pages that clear on the re-run are printed separately and do not fail the run `[2026-08-22: 925 pages in 449s at a concurrency of 6, which was the default at the time; zero cleared on re-check]`. **The mechanism is not established.** The explanation that used to sit in `smoke-pages.mjs`, and in this bullet — pages contending for one `hugo server`'s on-demand render — was never measured, and does not hold up: measured 2026-08-23 at concurrency 6 against 1 over 12 pages, navigation slowed 1.34x, JS settle time was 1.00x, and all 12 reached identical final DOM states — nowhere near enough to time a page out. Treat the re-check as a guard for an unexplained flake, not a fix for a known cause.
+- **That re-check is capped at 25 pages, and the concurrency default is no longer 6.** Both changed
+  2026-08-26 to match `site-characterization.mjs`, which is now the sibling this file tracks rather
+  than diverges from. The default is `min(24, max(6, availableParallelism()))` — 24 on a 24-core
+  box, still 6 on a small runner. **The 24 comes from the characterization harness's measurement
+  (925 pages, 12 -> 198s, 24 -> 114s, 12 -> 199s `[2026-08-24]`), not from one taken here**; both
+  drive one `chromium` with `browser.newPage()` per URL, but smoke adds a fixed 2s settle per page
+  that the other lacks, so do not quote 114s for a smoke run. Past 25 failures the sequential
+  re-check is skipped outright and the run says so, printing `recheckCapped: true` in its report:
+  a capture race does not reach hundreds of pages, so a failure that wide is systematic — which is
+  exactly what smoke is built to catch, and re-visiting ~925 pages at a 2s floor is 31 minutes
+  during which nothing is reported. Characterization hit that shape in CI `[run 32802721473,
+  2026-08-25]`. Both branches of the cap are proved to fire `[2026-08-26: same 33 forced failures
+  at concurrency 4, cap 2 -> capped message and no re-check, cap 100 -> sequential re-check ran]`.
 - **The harness sends a de-headlessed user agent.** forecast7.com (Cloudflare) answers 403 to a `HeadlessChrome` UA and 200 with an `Access-Control-Allow-Origin` header to a normal Chrome one, so the weatherwidget.io embed on `/data-features/heat-syndrome/` reported a CORS block and rendered at 0px under the sweep while working for visitors `[verified 2026-08-22: same run, same server — default UA 3 errors / 0px, de-headlessed 0 errors / 211px]`. A console error naming a third-party host can be the harness being fingerprinted; check what a real UA gets before allowlisting one.
 - **A CORS error from `airnowapi.org` on `(home)` is external — re-run before diagnosing it.** `themes/dohmh/layouts/partials/temp-popup.html` fetches that API at page load, and the AirNow `KNOWN_NOISE` entry is scoped to `realtime-air-quality` and different hostnames, so it does not cover this one `[verified 2026-08-17: one failure between two passes, on a tree where that file was unchanged from the pre-merge tip]`.
 

--- a/documents/smoke-env-plan-2026-08-26.md
+++ b/documents/smoke-env-plan-2026-08-26.md
@@ -1,0 +1,129 @@
+# Per-environment smoke invocation
+
+**Status as of 2026-08-26: DONE. All seven tasks landed in one commit, `4955a0a006` on
+`feature-smoke-env`, which is stacked on `feature-characterize-env` at `f5f780681b`.
+`npm run smoke:prod_prod` passes 925/925 in 156s at `4955a0a006`; `npm run smoke:env prod_prod
+sample` passes 33/33 in 128s.**
+
+**Owed to the branch below:** `characterize-env.mjs` should get the same `sample` second positional
+that Task 7 added here, so the two `:env` scripts keep one contract. Handed to the session that
+owns `feature-characterize-env` on 2026-08-26; not done in this worktree. If that session does not
+pick it up, the change is the Task 7 diff with `["--check"]` / `["--check", "--all"]` in place of
+`[]` / `["--all"]`.
+
+Derive what a status line cannot hold:
+
+```
+git log --oneline f5f780681b..HEAD                                   # the task commits
+git rev-list --left-right --count origin/production...HEAD           # right-hand number = unpushed
+gh pr list --head feature-smoke-env                                  # a PR, and against which base
+git merge-base --is-ancestor f5f780681b production                   # exit 0 once the branch below merged
+```
+
+## Why
+
+`npm run smoke` and `npm run smoke:all` can only check whichever environment
+`scripts/dev-server.mjs` happens to resolve: it reuses any server answering on :8080/:8081/:1313,
+and otherwise spawns `dev_stage` (`dev-server.mjs`, `SPAWN_ARGS`). Checking `prod_prod` — the
+environment that actually deploys — means starting a server by hand and exporting `DE_BASE_URL`.
+
+Two axes make that worth fixing rather than tolerating. `head.html` branches on the environment
+*name*, so only `prod_prod` emits production analytics and a non-`noindex` robots meta. And each
+environment pins its own `data_branch`, which changes the EHDP-data URLs the page fetches **at
+runtime** — a renamed or missing data file throws in the browser on one environment and not
+another, which is exactly the class of failure smoke exists to catch and a build cannot.
+
+`feature-characterize-env` solved the same problem for the characterization harness. This branch
+is the second caller of the module that branch extracted for the purpose:
+`scripts/isolated-server.mjs`, whose own header says so.
+
+## Decisions taken
+
+- **Stack on `feature-characterize-env` rather than copy `isolated-server.mjs`.** The branch is
+  cut from `f5f780681b` and its PR retargets to `production` when the one below merges — the
+  pattern CLAUDE.md settles under "Branching and deployment". The alternative was a second copy of
+  a module whose failure mode is corrupting a running server's `resources/_gen`; the extraction
+  commit `d14ab4e841` exists specifically so there would be one home for it.
+
+- **Positional environment argument, `--flag` rejected.** Copied wholesale from
+  `characterize-env.mjs`, including the reason: measured 2026-08-26 on npm 11.4.1 under
+  PowerShell, `npm run x -- --env prod_prod` reaches the script as `argv ["prod_prod"]` — npm eats
+  the flag NAME and PowerShell eats the `--`. Full measurement table in
+  `characterize-env-plan-2026-08-26.md`.
+
+- **`smoke:env` sweeps the full site by default.** Parallel to `characterize:site:env`, which
+  hardcodes `--check --all`. A run that pays for a cold Hugo build should not then check 33 pages.
+  **Amended 2026-08-26, same day:** the first version made this the *only* mode, which left no way
+  to check the curated list against a named environment short of starting a server by hand — so
+  Task 7 added the optional `sample` positional. The default is unchanged; `sample` is opt-in.
+
+- **Shared port :8090 with `characterize-env.mjs`, deliberately.** Both refuse to start when
+  something answers there, so the two cannot run concurrently. One isolated port is one thing to
+  reason about, and a stray survivor is easier to find than one of two.
+
+- **Concurrency default becomes `min(24, max(6, availableParallelism()))`, not a bare 24.** Same
+  formula as `site-characterization.mjs` (`CONCURRENCY_FLOOR` / `CONCURRENCY_CEILING`), so the two
+  harnesses agree, and so a 2-core CI runner is not handed 24-way browser concurrency. Both
+  harnesses drive one `chromium` instance with `browser.newPage()` per URL, so the mechanism the
+  characterization measurement covers is the same one here.
+
+- **Cap the sequential re-check at 25, matching the characterization harness.** Scope beyond the
+  original request, approved 2026-08-26. `smoke-pages.mjs`'s re-check is uncapped, and smoke's own
+  target failure — a bad edit to `head.html` or `assets/js/` — fails every page. Each re-visit
+  carries a fixed `page.waitForTimeout(2000)`, so ~925 sequential re-visits is 31 minutes at an
+  absolute floor. CLAUDE.md records the same shape hitting characterization in CI: a one-line
+  template edit sent it into a 12-minute sequential re-capture of all 925 and it hit
+  `timeout-minutes: 20` having reported nothing (run 32802721473, 2026-08-25).
+
+- **CI is out of scope.** `.github/workflows/` calls the scripts directly and passes
+  `DE_BASE_URL`, which takes `ensureDevServer`'s path 1 and never reaches the spawn logic. The
+  concurrency default is the one change here that CI *can* see; check what any smoke workflow
+  passes before assuming it is insulated.
+
+## Tasks
+
+| # | Step | Commit | Status | Proof that ran |
+|---|---|---|---|---|
+| 1 | `scripts/smoke-env.mjs` — positional env, :8090 guard, `startServer`, pagefind build, drive `smoke-pages.mjs` as a child | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: four argument arms — no args, `nonsuch`, `--env prod_prod`, two positionals — each exit 2 with its own message; `node --check` clean]`. Task 7 then made two positionals legal and re-ran the arms |
+| 2 | `DEFAULT_CONCURRENCY` formula in `smoke-pages.mjs` | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: formula resolves to 24 on this box (24 logical processors)]`. **The planned A/B/A wall-time was NOT run** — see Deferred |
+| 3 | Cap the sequential re-check at 25 in `smoke-pages.mjs` | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: two-arm control on a copy reading the cap from an env var, same 33 forced failures (bogus `DE_BASE_URL`) at `--concurrency 4`; cap 2 -> capped message, no `Re-checking` line; cap 100 -> `Re-checking 33 failing page(s) sequentially`, no capped message]` |
+| 4 | `package.json`: `smoke:env`, `smoke:prod_prod` | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: `npm run smoke:env` prints usage, exit 2; `npm run smoke:env nonsuch` reaches the script with the positional intact]` |
+| 5 | Docs: CLAUDE.md smoke section, `readme-development.md` | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: `npm run docs-check` reports the same 2 pre-existing failures with and without these edits (stash control), and a bogus path injected into the added sentence WAS caught — so the zero-new-failures reading is from a probe proved able to fire]` |
+| 6 | End-to-end: `npm run smoke:prod_prod` | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: exit 0 in 171s wall, cold prod_prod build + Pagefind + sweep included. "Pagefind index: served". 925 pages = 830 sitemap + 94 paginator + 1, matching the breakdown CLAUDE.md records. Report JSON parses to a dict with concurrency 24, mode "all", pagesChecked 925, recheckCapped False (real bool), failures [], baseURL http://localhost:8090/IndicatorPublic/. One page failed concurrently and cleared on the sequential re-run, which exercised the below-cap branch in the real harness. `hugo.exe` gone and :8090 free afterwards]`. **Re-run after Task 7 refactored the hardcoded `--all` into `sweepArgs`, because the first run was a fact about the older code** `[2026-08-26: exit 0 in 156s, 925/925, zero FAIL lines, report mode "all" / concurrency 24 / failures [] / clearedOnRecheck []]` |
+| 7 | Optional second positional `sample` in `smoke-env.mjs`, plus its doc lines | `feature-smoke-env @ 4955a0a006` | **DONE 2026-08-26** | `[2026-08-26: five rejection arms each exit 2 — no args, bad env, `--env`, `prod_prod typo`, three positionals. End-to-end `npm run smoke:env prod_prod sample` exit 0 in 128s, 33/33 clean; its report reads mode "curated", pagesChecked 33, concurrency 1 against the SAME baseURL http://localhost:8090/IndicatorPublic/ that the full run used — so the word, and only the word, changed the page set. Server reaped, :8090 free]` |
+
+## Environment state
+
+- Worktree `EH-dataportal.worktrees/feature-smoke-env`; `feature-characterize-env` is checked out
+  in a **separate worktree** and moved once mid-session already (`4715de67e4` → `f5f780681b`).
+  Re-read anything imported from it rather than trusting an earlier read.
+- No upstream is set on this branch (`git config --get branch.feature-smoke-env.merge` is empty),
+  which is correct — it was cut from a local ref.
+- Task 6 spawns a Hugo server on :8090 and writes under `%TEMP%/sc-isolated`. If a run is
+  interrupted, look for a surviving `hugo.exe` before re-running; `TaskStop` does not reap the
+  process tree. After the 2026-08-26 runs, no `hugo.exe` remained and :8090 had no listener. Note
+  that `Get-NetTCPConnection -LocalPort 8090` still lists entries for a few minutes afterwards —
+  those are `TimeWait` with `OwningProcess 0`, not a leak. The guard in `smoke-env.mjs` issues an
+  HTTP GET rather than reading the port table, and gets `ECONNREFUSED` against them, so it is
+  unaffected `[verified 2026-08-26]`.
+- **`docs/` and `resources/_gen/` do not exist in this worktree** — no build has ever run here.
+  That is why `npm run docs-check` reports two "path does not exist" failures on CLAUDE.md, on a
+  clean tree as much as a dirty one; they are not caused by anything on this branch. It also means
+  the end-to-end run did **not** test the isolation claim in any strong sense: both were absent
+  before and after, so there was nothing there to corrupt. To actually test it, run a build in this
+  worktree first, snapshot `resources/_gen`, then run `smoke:env`.
+
+## Deferred
+
+- **The 6-vs-24 A/B/A wall-time measurement for this harness.** Task 2's concurrency ceiling is
+  carried over from `site-characterization.mjs`, whose 24 was measured on *that* harness
+  (925 pages, 12 -> 198s, 24 -> 114s, 12 -> 199s `[2026-08-24]`). The mechanism transfers — both
+  drive one `chromium` with `browser.newPage()` per URL — but smoke adds a fixed
+  `page.waitForTimeout(2000)` per page that characterization does not, so its wall time has a floor
+  the other lacks and the 114s figure must not be quoted for a smoke run. Nothing here asserts a
+  smoke timing that was not measured, so this is a nice-to-have, not a correction owed.
+  **What would un-defer it:** wanting to move `CONCURRENCY_CEILING` off 24. Raising the ceiling
+  requires measuring above it first, per the comment in the file. Run it as A/B/A against one
+  already-running isolated server (`node scripts/smoke-pages.mjs --all --concurrency N`, three
+  sweeps, 6/24/6) — a single 6-vs-24 pair measures order, not concurrency, because the first sweep
+  warms the caches for the rest.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "lint": "eslint assets/js/data-explorer",
         "smoke": "node scripts/smoke-pages.mjs",
         "smoke:all": "node scripts/smoke-pages.mjs --all --report scripts/smoke-reports/",
+        "smoke:env": "node scripts/smoke-env.mjs",
+        "smoke:prod_prod": "node scripts/smoke-env.mjs prod_prod",
         "characterize:cp": "node scripts/cp-characterization.mjs",
         "characterize:site": "node scripts/site-characterization.mjs --check --all",
         "characterize:site:sample": "node scripts/site-characterization.mjs --check",

--- a/readme-development.md
+++ b/readme-development.md
@@ -92,8 +92,10 @@ templates compile.
 |---|---|
 | `npm run smoke` | Loads 33 pages, one per template kind, and fails on any JavaScript error. Fast. |
 | `npm run smoke:all` | The same, over every page the site serves. For a pre-merge sweep. |
+| `npm run smoke:env <env> [sample]` | The same, against a named environment it builds and serves itself. |
 | `npm run characterize:site` | Loads every page and compares its *structure* — assets, heading levels, `alt` text, tables, JSON-LD, overflow — against a committed baseline. |
 | `npm run characterize:site:sample` | The same check over 41 pages, one per template kind. |
+| `npm run characterize:site:env <env>` | The same check, against a named environment it builds and serves itself. |
 
 Run `smoke` before merging anything that touches `partials/head.html`, `_default/baseof.html`, the
 header or footer partials, or `assets/js/`. Neither check sees what the other does: `smoke` catches
@@ -101,24 +103,42 @@ JavaScript that throws, characterization catches a page whose markup quietly mov
 
 #### Checking a specific environment
 
-`npm run characterize:site` checks whichever environment your machine happens to be serving — it
-reuses any Hugo server already answering on :8080, :8081 or :1313, and otherwise starts `dev_stage`
-for you. When you need a *named* environment instead, and especially `prod_prod`, which is the one
-that actually deploys:
+`npm run smoke` and `npm run characterize:site` check whichever environment your machine happens to
+be serving — they reuse any Hugo server already answering on :8080, :8081 or :1313, and otherwise
+start `dev_stage` for you. When you need a *named* environment instead, and especially `prod_prod`,
+which is the one that actually deploys, both checks have an `:env` form:
 
 ```bash
+npm run smoke:prod_prod                    # every page, JavaScript errors, prod_prod
+npm run smoke:env local_prod               # any environment in config/
+npm run smoke:env local_prod sample        # the curated 33 pages instead of all of them
+
 npm run characterize:site:prod_prod        # the environment the live site is built with
 npm run characterize:site:dev_stage        # staging data, deterministically
 npm run characterize:site:env local_prod   # any environment in config/
 ```
 
+Add the word `sample` to check the curated one-page-per-template list rather than the whole site.
+A full Hugo build runs either way, so `sample` narrows *what* gets checked rather than making the
+command quick.
+
 These start their own Hugo server on port 8090, build it entirely outside the repo, and stop it
 when they finish — so they ignore whatever you have running, and they leave `docs/` and
-`resources/_gen` untouched. They are slower than `characterize:site`, because a full build runs
-before the check does.
+`resources/_gen` untouched. They are slower than the plain forms, because a full build runs before
+the check does. They share that one port, so **you cannot run a `smoke:env` and a
+`characterize:site:env` at the same time** — the second one to start says so and exits rather than
+sweep the wrong site.
 
-Two baselines are committed, between them covering four of the eight environments. The rest
-stop and say which baselines exist:
+Two things make the environment worth naming rather than taking what you are given. `head.html`
+branches on the environment's *name*, so only `prod_prod` gets the production analytics property
+and a page that search engines are allowed to index. And each environment pins its own
+EHDP-data branch, which changes the data URLs a page fetches **in the browser** — so a data file
+that was renamed on one branch throws a JavaScript error on that environment only, which is
+exactly what `smoke:env` is for and what a green `hugo` build cannot see.
+
+`smoke:env` works on all eight environments — it needs no baseline, only a page that loads without
+throwing. Characterization compares against a committed baseline, and two are committed, between
+them covering four of the eight. The rest stop and say which baselines exist:
 
 | Environment | Baseline used |
 |---|---|
@@ -128,9 +148,10 @@ stop and say which baselines exist:
 
 **Pass the environment as a plain word, not as a flag.** `npm run characterize:site:env prod_prod`
 works; `npm run characterize:site:env --env prod_prod` does not, because PowerShell and npm between
-them discard the flag's name and keep only its value. The scripts refuse anything starting with `-`
-rather than act on a mangled argument. If you need the underlying flags, call the script directly:
-`node scripts/site-characterization.mjs --check --content`.
+them discard the flag's name and keep only its value. Both `:env` scripts refuse anything starting
+with `-` rather than act on a mangled argument. If you need the underlying flags, call the script
+directly: `node scripts/site-characterization.mjs --check --content`, or
+`node scripts/smoke-pages.mjs --all --concurrency 12`.
 
 #### When a check fails
 

--- a/scripts/smoke-env.mjs
+++ b/scripts/smoke-env.mjs
@@ -1,0 +1,150 @@
+// Run the smoke test against ONE named Hugo environment.
+//
+//   node scripts/smoke-env.mjs prod_prod            every page the site serves
+//   node scripts/smoke-env.mjs prod_prod sample     the curated one-per-template list
+//   npm run smoke:env prod_prod
+//   npm run smoke:env prod_prod sample
+//
+// The smoke test itself needs no new flag: dev-server.mjs honours DE_BASE_URL
+// and probes Pagefind on whatever it is pointed at. So the whole job here is
+// starting the right server and pointing the harness at it — which is what
+// isolated-server.mjs does, and what characterize-env.mjs already does for the
+// characterization harness. This is that module's second caller.
+//
+// WHY per-environment smoke is worth a script, given that a console error is
+// mostly environment-independent: two axes are not. head.html branches on the
+// environment NAME, so only prod_prod gets production analytics and a
+// non-noindex robots meta. And each environment pins its own data_branch, which
+// changes the EHDP-data URLs the page fetches AT RUNTIME — a renamed or missing
+// data file throws in the browser on one environment and not another. That is
+// the class of failure smoke exists to catch and a green build cannot see.
+//
+// HOW THIS DIFFERS FROM `npm run smoke` / `npm run smoke:all`:
+//
+//   smoke, smoke:all   resolve a server through dev-server.mjs: reuse whatever
+//                      answers on :8080/:8081/:1313, and failing that spawn
+//                      dev_stage and build into the repo's own docs/ and
+//                      resources/_gen. So WHICH environment gets checked
+//                      depends on what you have running.
+//   smoke:env X        ignores every running server, spawns X on :8090 with
+//                      both writable outputs redirected outside the repo, and
+//                      stops it afterwards. Deterministic, and it leaves docs/
+//                      and resources/_gen untouched.
+//
+// The page set is the full site by default and the curated list with `sample`.
+// Note that a cold Hugo build runs either way, so `sample` saves the sweep and
+// not the build — it is for narrowing WHAT is checked, not for a quick check.
+//
+// Arguments are POSITIONAL on purpose, and a `--flag` is rejected rather than
+// half-honoured. Measured 2026-08-26 (npm 11.4.1, PowerShell): `npm run x --
+// --env prod_prod` reaches the script as argv ["prod_prod"] — PowerShell eats
+// the `--` and npm eats the flag NAME, leaving its value as a nameless
+// positional. A bare positional survives both intact. Flags remain available by
+// calling smoke-pages.mjs directly. Same contract as characterize-env.mjs; the
+// full measurement table is in documents/characterize-env-plan-2026-08-26.md.
+
+import { execFileSync, execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ISO_ROOT, PORT, responds, startServer } from "./isolated-server.mjs";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+// Where a full-site run leaves its JSON report — the same directory and the
+// same timestamped filenames `npm run smoke:all` uses, so the two modes' runs
+// sit side by side. Gitignored.
+const REPORT_DIR = "scripts/smoke-reports/";
+
+// Every environment config/ actually holds. Read from disk rather than listed
+// here, so adding an environment needs no edit in this file — and so a typo is
+// caught before a cold Hugo build, not after one.
+const environments = () => readdirSync(`${REPO_ROOT}/config`, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && e.name !== "_default")
+    .map((e) => e.name)
+    .sort();
+
+// The optional second positional. A bare word rather than a flag, for the same
+// reason the environment is: measured on the branch below, `npm run x local_prod
+// extra` reaches the script as argv ["local_prod","extra"] — positionals survive
+// npm and PowerShell intact where a `--flag` does not. Spelled out rather than
+// accepted loosely, so a typo stops the run instead of silently sweeping 925
+// pages when 33 were wanted.
+const SAMPLE = "sample";
+
+const usage = (message) => {
+    console.error(`${message}\n`);
+    console.error("  node scripts/smoke-env.mjs <environment> [sample]");
+    console.error("  npm run smoke:env <environment> [sample]\n");
+    console.error(`Environments: ${environments().join(", ")}\n`);
+    console.error("Sweeps every page the site serves, like `npm run smoke:all`. Add the word");
+    console.error(`\`${SAMPLE}\` for the curated one-page-per-template list instead, like \`npm run smoke\`.`);
+    console.error("Flags are not accepted here — npm and PowerShell mangle them; for those, call");
+    console.error("node scripts/smoke-pages.mjs directly.");
+    process.exit(2);
+};
+
+async function main() {
+
+    const args = process.argv.slice(2);
+
+    const flag = args.find((a) => a.startsWith("-"));
+    if (flag) usage(`This script takes no flags, and "${flag}" would not have survived npm intact.`);
+    if (args.length < 1) usage("No environment given.");
+    if (args.length > 2) usage(`Expected an environment and optionally "${SAMPLE}", got ${args.length} arguments.`);
+
+    const [environment, mode] = args;
+    if (!environments().includes(environment)) usage(`No config/${environment}/ in this repo.`);
+    if (mode !== undefined && mode !== SAMPLE) usage(`Second argument must be "${SAMPLE}" or absent, not "${mode}".`);
+
+    // Full site unless asked otherwise. --all is what makes smoke-pages.mjs
+    // enumerate the site; without it, it reads its curated PAGES list.
+    const sweepArgs = mode === SAMPLE ? [] : ["--all"];
+
+    // Same guard characterize-env.mjs keeps, and it now guards against that
+    // script too: :8090 is this port precisely because nothing else probes it,
+    // so anything answering there is either a sibling run or a server a
+    // previous run failed to reap.
+    if (await responds(`http://localhost:${PORT}/`)) {
+        console.error(`Something is already answering on :${PORT}. This script needs that port `
+            + `for its own server. If a previous run was interrupted, look for a surviving hugo.`);
+        process.exit(2);
+    }
+
+    console.log(`Isolated build under ${ISO_ROOT}`);
+    const { baseURL, destDir, stop } = await startServer(environment);
+    console.log(`  serving ${baseURL}`);
+
+    try {
+        // Not optional. `hugo server` never builds the search index, and
+        // dev-server.mjs only builds one for servers it STARTS — a DE_BASE_URL
+        // server gets a probe and nothing else. Without the index, PagefindUI
+        // is undefined on every page: with the conditional allowlist entry
+        // forced off, smoke failed 33 of 33 `[2026-08-24, recorded in
+        // CLAUDE.md]`. Allowing it through the allowlist instead would work,
+        // but would mean this mode alone never checks the search UI.
+        //
+        // Same command the deploy workflow runs.
+        console.log("  building the Pagefind index");
+        execSync(`npx -y pagefind --site "${destDir}"`, { cwd: REPO_ROOT, stdio: "ignore" });
+
+        // Driven as a child rather than imported, for the reason
+        // characterize-env.mjs gives: smoke-pages.mjs is a CLI that reads
+        // process.argv and sets process.exitCode. DE_BASE_URL takes
+        // ensureDevServer's path 1, which trusts the URL, probes Pagefind on it
+        // and returns a no-op stop — teardown stays this script's job.
+        execFileSync(process.execPath, ["scripts/smoke-pages.mjs", ...sweepArgs, "--report", REPORT_DIR], {
+            cwd: REPO_ROOT,
+            stdio: "inherit",
+            env: { ...process.env, DE_BASE_URL: baseURL },
+        });
+    } catch (e) {
+        // The harness's own output above names the failing pages. Its exit code
+        // is the verdict and is passed straight through.
+        process.exitCode = typeof e.status === "number" ? e.status : 1;
+    } finally {
+        stop();
+        console.log(`  stopped the ${environment} server`);
+    }
+}
+
+main();

--- a/scripts/smoke-pages.mjs
+++ b/scripts/smoke-pages.mjs
@@ -7,10 +7,13 @@
 // that touches a shared template (head.html, baseof.html, the header/footer
 // partials) or any file under assets/js/.
 //
-// Two modes:
-//   npm run smoke        one page per template kind (the PAGES list), sequential
-//   npm run smoke:all    every page the site serves, concurrent — for a
-//                        pre-merge or pre-deploy sweep
+// Three modes. The first two take whatever server dev-server.mjs resolves; the
+// third picks the environment itself, through scripts/smoke-env.mjs.
+//   npm run smoke             one page per template kind (the PAGES list), sequential
+//   npm run smoke:all         every page the site serves, concurrent — for a
+//                             pre-merge or pre-deploy sweep
+//   npm run smoke:env <env>   every page, against an isolated server for ONE
+//                             named Hugo environment (see smoke-env.mjs)
 //
 //   node scripts/smoke-pages.mjs --all --concurrency 12
 //   DE_BASE_URL="http://localhost:1313/dev-prod/" npm run smoke   # existing server
@@ -21,6 +24,7 @@
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
+import { availableParallelism } from "node:os";
 import { chromium } from "playwright";
 import { ensureDevServer } from "./dev-server.mjs";
 import { collectAllPaths, mapPool } from "./site-urls.mjs";
@@ -126,10 +130,41 @@ const isKnownNoise = (text, path) =>
     KNOWN_NOISE.some(({ page, error, when }) =>
         error.test(text) && (page === null || page.test(path)) && (when === undefined || when()));
 
-// Default browser concurrency for --all. Six pages against one `hugo server`
-// leaves headroom on a machine that is also being used for something else;
-// --concurrency raises it.
-const DEFAULT_CONCURRENCY = 6;
+// Default browser concurrency for --all. Derived from the machine rather than
+// fixed, and the same formula site-characterization.mjs uses, so the repo's two
+// sweeps behave alike on the same box — the cores available differ by an order
+// of magnitude between a dev workstation and a GitHub Actions runner, and a
+// number tuned for one starves or overcommits the other.
+//
+// The bounds come from a measurement of the OTHER harness, not this one:
+// 925 pages, three interleaved sweeps, 12 -> 198s, 24 -> 114s, 12 -> 199s
+// `[2026-08-24, 24 logical processors]`. That transfers as far as the mechanism
+// does — both harnesses drive one chromium instance with browser.newPage() per
+// URL — and no further. This harness adds a fixed 2s settle per page that the
+// other does not have, which puts a floor under any wall time here. 6 is the
+// value this file ran at before 2026-08-26; 24 is the highest tried anywhere in
+// the repo. Raising the ceiling means measuring above it first.
+const CONCURRENCY_FLOOR = 6;
+const CONCURRENCY_CEILING = 24;
+const DEFAULT_CONCURRENCY = Math.min(
+    CONCURRENCY_CEILING,
+    Math.max(CONCURRENCY_FLOOR, availableParallelism()),
+);
+
+// How many concurrent failures get a sequential re-check before the harness
+// stops re-checking and says so. Same cap, for the same reason, as
+// site-characterization.mjs's re-capture limit.
+//
+// A capture race does not reach hundreds of pages at once, so a failure that
+// wide is systematic — and systematic is precisely what this harness exists to
+// catch: one bad edit to head.html or a file under assets/js/ throws on every
+// page. Each re-visit carries the fixed 2s settle below, so re-checking ~925
+// pages sequentially is 31 minutes at an absolute floor, and the run reports
+// nothing until it finishes. The characterization harness hit exactly this: a
+// one-line template edit that moved `lang` on every page sent its CI job into a
+// 12-minute sequential re-capture of all 925 and it hit `timeout-minutes: 20`
+// having reported nothing `[run 32802721473, 2026-08-25]`.
+const RECHECK_CAP = 25;
 
 // Minimal flag parsing — three flags do not justify a dependency.
 const parseArgs = (argv) => {
@@ -240,6 +275,10 @@ const main = async () => {
 
     let failures = [];
     let cleared = [];
+    // True when the sequential re-check was skipped outright because more pages
+    // failed than RECHECK_CAP, which makes every failure below a plain
+    // concurrent result with nothing ruling out contention.
+    let capped = false;
 
     try {
         let done = 0;
@@ -273,7 +312,13 @@ const main = async () => {
         // final DOM states `[2026-08-23]`. The re-check is a guard for an unexplained
         // flake, not a fix for a known cause. site-characterization.mjs hit the same
         // wall and reaches for the same guard.
-        if (concurrency > 1 && failures.length) {
+        if (concurrency > 1 && failures.length > RECHECK_CAP) {
+            capped = true;
+            console.log(`\n${failures.length} page(s) failed — past the ${RECHECK_CAP}-page re-check `
+                + `cap, so they are reported as swept and NOT re-checked sequentially. A capture `
+                + `race does not reach this many pages at once; a failure this wide is systematic. `
+                + `Nothing below is arbitrated, so treat every page named as a real failure.`);
+        } else if (concurrency > 1 && failures.length) {
             console.log(`\nRe-checking ${failures.length} failing page(s) sequentially...`);
             const rechecked = [];
             for (const { path } of failures) {
@@ -311,7 +356,12 @@ const main = async () => {
             concurrency,
             gitHead: gitHead(),
             pagesChecked: paths.length,
+            // `clearedOnRecheck` is the subset that failed concurrently and was
+            // clean sequentially — contention rather than a real error.
+            // `recheckCapped` says that re-check was skipped altogether, so a
+            // consumer knows nothing here was arbitrated.
             clearedOnRecheck: cleared,
+            recheckCapped: capped,
             failures,
             signatures,
         });


### PR DESCRIPTION
Gives `smoke` the same per-environment invocation `characterize:site` got in #1482, and brings the two harnesses' concurrency and re-check behaviour into line.

```bash
npm run smoke:prod_prod                 # every page, on an isolated prod_prod server
npm run smoke:env local_prod            # any environment in config/
npm run smoke:env local_prod sample     # the curated 33 instead
```

## Why per-environment smoke

`npm run smoke` can only check whichever environment `dev-server.mjs` happens to resolve — it reuses any server on :8080/:8081/:1313, and otherwise spawns `dev_stage`. Two axes make that a real gap rather than a convenience:

- `head.html` branches on the environment **name**, so only `prod_prod` gets the production analytics property and an indexable robots meta.
- Each environment pins its own `data_branch`, which changes the EHDP-data URLs a page fetches **at runtime**. A renamed data file throws in the browser on one environment and not another — exactly what smoke exists to catch, and what a green `hugo` build cannot see.

## What's here

**`scripts/smoke-env.mjs`** — second caller of `scripts/isolated-server.mjs`, which #1482 extracted for the purpose. Isolated server on :8090, both writable outputs redirected outside the repo, Pagefind built into it, server stopped afterwards. Positional environment argument with `--flag` rejected, same contract as `characterize-env.mjs`. The optional `sample` word is compared exactly, so a typo exits 2 rather than quietly sweeping 925 pages when 33 were wanted.

`smoke-pages.mjs` needed no change to support it — `ensureDevServer`'s `DE_BASE_URL` path already does the right thing.

**Two changes to `scripts/smoke-pages.mjs`**, both adopting `site-characterization.mjs`'s existing behaviour:

- `DEFAULT_CONCURRENCY` becomes `min(24, max(6, availableParallelism()))` — 24 on a 24-core box, still 6 on a small runner. Affects `--all` mode only; plain `npm run smoke` is unchanged at 33 pages, concurrency 1.
- The sequential re-check is capped at 25 pages, with `recheckCapped` in the report. Past that a failure is systematic rather than a capture race, and re-visiting ~925 pages at a 2s settle floor reports nothing for 31 minutes. Characterization hit that shape in CI (run 32802721473).

## Verification

- `npm run smoke:prod_prod` — exit 0, **925/925 clean in 156s**, report `mode: all` / `concurrency: 24` / `failures: []`.
- `npm run smoke:env prod_prod sample` — exit 0, **33/33 clean in 128s**, report `mode: curated` / `pagesChecked: 33` / `concurrency: 1`, against the same baseURL. Same script, same server; only the trailing word differed.
- Five argument-rejection arms each exit 2 with their own message.
- Both re-check branches proved to fire, under a two-arm control over the same 33 forced failures: cap 2 skips the re-check, cap 100 runs it.
- `docs-check` reports no new failures. Its two existing ones (`docs/`, `resources/_gen`) are absent-directory artefacts of a fresh worktree and reproduce on a clean tree.

## Two things a reviewer should know

**The 24 was not measured on this harness.** It is carried over from characterization's measurement (925 pages, 12 → 198s, 24 → 114s, 12 → 199s). The mechanism transfers — both drive one `chromium` with `browser.newPage()` per URL — but smoke adds a fixed 2s settle per page that characterization does not, so that 114s must not be quoted for a smoke run. The code comment says so, and `documents/smoke-env-plan-2026-08-26.md` records the A/B/A that would settle it.

**The isolation claim is not strongly tested here.** `docs/` and `resources/_gen/` do not exist in the worktree this ran in, so they were absent before and after — there was nothing to corrupt. The mechanism is #1482's, unchanged.

Full decisions, proofs and deferred items: `documents/smoke-env-plan-2026-08-26.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
