### PR TITLE
Run the smoke check automatically on every PR into production

### DIFF
--- a/.github/workflows/site-characterization.yml
+++ b/.github/workflows/site-characterization.yml
@@ -301,12 +301,15 @@ jobs:
   # ONLY THE SITE SOURCE COMES FROM THE BASE. The harness and the baseline
   # stay at this PR's head on purpose: a PR that also edits the harness or
   # re-captures the baseline would otherwise move three variables at once,
-  # and the question is only about the first. It is also the only shape that
-  # runs at all today — `production` carries neither
-  # `scripts/site-characterization.mjs` nor a baseline directory
-  # `[verified 2026-08-24: git ls-tree production, both ABSENT]`, so a job
-  # that checked the base out wholesale would die on a missing file rather
-  # than report a finding.
+  # and the question is only about the first.
+  #
+  # This comment used to add that the split was the only shape that ran at
+  # all, because `production` carried neither the harness nor a baseline. That
+  # was true when written on 2026-08-24 and PRs #1482 and #1483 made it false:
+  # `production` now carries `scripts/site-characterization.mjs` and
+  # `scripts/site-characterization-baseline/` both `[verified 2026-08-26:
+  # git ls-tree --name-only production -- scripts/]`. The reason above is the
+  # one that survives, and it is sufficient on its own.
   #
   # base.sha is the BASE BRANCH TIP, not the merge base
   # `[verified 2026-08-24: on PR #1480 baseRefOid is d862072bea, which is

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -206,6 +206,29 @@ jobs:
       - name: Build the search index with Pagefind
         run: npx -y pagefind --site docs
 
+      # A green run must not be able to mean "the check was blind". KNOWN_NOISE
+      # has one CONDITIONAL entry — { page: null, error: /pagefind/i, when: ()
+      # => !pagefindServed } (smoke-pages.mjs:115) — so if the index is missing,
+      # every Pagefind error on every page is allowlisted and the sweep passes
+      # while testing nothing about search. What that hides was measured: with
+      # the predicate forced off and no index, smoke failed 33 of 33, and the
+      # masked errors included `PagefindUI is not defined` on every page
+      # `[2026-08-24, recorded in CLAUDE.md]`.
+      #
+      # So assert the index is SERVED rather than trusting the step above to
+      # have worked. Through the server, not the filesystem, because what
+      # matters is what the browser will get — and this is the same asset
+      # dev-server.mjs probes to set that predicate (PAGEFIND_PROBE,
+      # dev-server.mjs:67).
+      #
+      # Proved to discriminate rather than assumed to: against an isolated
+      # prod_prod server this path is 404 before the Pagefind build and 200
+      # after, and `curl -f` exits 22 on the former and 0 on the latter
+      # `[verified 2026-08-26]`.
+
+      - name: Confirm Pagefind is served
+        run: curl -fsS -o /dev/null "${SERVER_URL}pagefind/pagefind.js"
+
       # ---------------------------------------------------------------------
       # the check
       #

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,275 @@
+name: Smoke check
+
+# Loads every page the site serves under Playwright and fails on any console
+# `error` or `pageerror` that is not allowlisted in smoke-pages.mjs. It is the
+# only check in this repo that RUNS the site's JavaScript.
+#
+# That matters because a green Hugo build proves the templates compile and
+# nothing more: the site's browser JS is classic <script> tags sharing one
+# global scope, so a bad edit throws at load while the build stays green.
+#
+# Complements site-characterization.yml rather than overlapping it. That one
+# fails on a page whose rendered STRUCTURE moved; this one fails on a page
+# whose JS THREW. Neither sees what the other does, which is why they are two
+# workflows and two checks in the PR list.
+#
+# It builds with `--environment prod_prod` for two reasons, and only the second
+# is specific to smoke. head.html branches on the environment NAME, so
+# prod_prod is the only environment whose emitted <head> matches the deployed
+# site. And each environment pins its own data_branch: pages fetch EHDP-data
+# from raw GitHub URLs AT RUNTIME, so a renamed data file throws in the browser
+# on one environment and not another. prod_prod pins EHDP-data's `production`,
+# which is the data the site deploys against.
+#
+# Analytics do not fire. smoke-pages.mjs aborts www.googletagmanager.com at the
+# network layer (BLOCKED_HOSTS), so the external gtag.js never loads and the
+# inline gtag() calls reach nothing but a local dataLayer. Without that, a
+# 925-page sweep would report 925 page views to the live property on every PR.
+#
+# A red run is not always this PR's doing: pages embed third parties that go
+# down, and EHDP-data moves independently of this repo. CLAUDE.md records an
+# AirNow CORS error appearing on (home) once between two passes on an unchanged
+# tree `[verified 2026-08-17]`. Read the artifact before treating red as a
+# regression.
+
+on:
+  pull_request:
+    branches:
+      - production
+      - development
+
+    # Copied verbatim from site-characterization.yml, and for the same reason:
+    # a docs-only push should not spend a full 925-page sweep. Nothing listed
+    # here can reach a rendered page — Hugo builds from content/, themes/,
+    # assets/, data/, static/, config/ and archetypes/, and none of these are
+    # among them.
+    #
+    # Deliberately NOT ignored: content/**/*.md is the site's own copy, so a
+    # blanket `**.md` would skip real content changes.
+    #
+    # WARNING: do not make this a REQUIRED status check while it has a path
+    # filter. GitHub: "Associated checks stay in a 'Pending' state and block
+    # merging" when a workflow is skipped by path filtering
+    # `[docs.github.com/en/pull-requests/collaborating-with-pull-requests/
+    # collaborating-on-repositories-with-code-quality-features/
+    # troubleshooting-required-status-checks, read 2026-08-24]`.
+    paths-ignore:
+      - documents/**
+      - memories/**
+      - .claude/**
+      - .agents/**
+      - CLAUDE.md
+      - README.md
+      - readme-components.md
+      - readme-content.md
+      - readme-development.md
+      - LICENSE
+
+  workflow_dispatch:
+
+    inputs:
+
+      scope:
+        description: Pages to sweep
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - sample
+
+# read-only: this workflow reports, it never publishes
+permissions:
+  contents: read
+
+env:
+  TZ: America/New_York
+  SERVER_PORT: 8080
+  # prod_prod's baseURL is https://a816-dohbesp.nyc.gov/IndicatorPublic/, and
+  # `hugo server` keeps the path while replacing the host
+  # `[verified 2026-08-24: 200 on /IndicatorPublic/, 404 on / and /dev-stage/]`.
+  SERVER_URL: http://localhost:8080/IndicatorPublic/
+
+jobs:
+
+  # -------------------------------
+  # run the site's JS on every page
+  # -------------------------------
+
+  smoke:
+    name: Load every page and fail on a console error
+    runs-on: ubuntu-24.04
+
+    # PLACEHOLDER, and knowingly unmeasured — no smoke sweep has ever been
+    # timed on a runner. The only figure derivable without measuring is a
+    # floor, and it comes from the harness's own constant rather than from the
+    # system: visit() does a fixed 2s settle per page, so 925 pages at
+    # concurrency 6 spend 308s in settle alone, before any navigation.
+    # ubuntu-24.04 reports 4 logical processors, so
+    # min(24, max(6, availableParallelism())) floors at 6 here
+    # `[run 32777189174: "Concurrency: 6 (4 logical processors)"]`.
+    # Task 5 of documents/smoke-workflow-plan-2026-08-26.md reads the real
+    # number off the first run and Task 6 replaces this line with it.
+    timeout-minutes: 30
+
+    concurrency: # one run per ref; a superseded PR push doesn't need its own sweep
+      group: ${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
+
+    steps:
+
+      # fetch-depth 1: the harness reads `git rev-parse HEAD` for the report
+      # metadata (gitHead(), smoke-pages.mjs) and needs no history beyond the tip
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      # npm ci, not npm install: the lockfile pins hugo-extended 0.147.3, the
+      # same release the deploy workflows install through peaceiris/actions-hugo.
+      # Using the locked binary keeps one Hugo in the repo instead of two.
+
+      - name: Install dependencies
+        run: npm ci
+
+      # hugo-extended is an OPTIONAL dependency, so a failed platform binary
+      # install is silent. Fail here, where the message is legible, rather than
+      # as a server that never answers.
+
+      - name: Confirm the locked Hugo is present
+        run: npx hugo version
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      # ---------------------------------------------------------------------
+      # the site under test
+      #
+      # The workflow owns the server rather than letting scripts/dev-server.mjs
+      # spawn one: dev-server.mjs waits a fixed 90s for the first 200, and a
+      # cold CI build fetching remote EHDP-data resources has no cache to hit.
+      # ---------------------------------------------------------------------
+
+      - name: Start the Hugo server
+        run: |
+          npx hugo server \
+            --environment prod_prod \
+            --cleanDestinationDir \
+            --disableFastRender \
+            -p "${SERVER_PORT}" > hugo-server.log 2>&1 &
+          echo "HUGO_PID=$!" >> "$GITHUB_ENV"
+
+      # Bounded by the CLOCK, not by an attempt count. Hugo accepts a
+      # connection BEFORE the build finishes and holds it open, so a poll
+      # cannot catch a half-built site — but it also means one attempt can
+      # block for as long as the build takes: on the runner a single curl
+      # blocked for 61 seconds inside one iteration, and a loop counting
+      # attempts reported that as "after 2s"
+      # `[run 32771116783, 2026-08-24]`. --max-time caps one attempt so a
+      # wedged connection cannot swallow the whole budget silently.
+
+      - name: Wait for the server
+        run: |
+          deadline=$(( SECONDS + 300 ))
+          while [ "${SECONDS}" -lt "${deadline}" ]; do
+            if curl -fsS --max-time 120 -o /dev/null "${SERVER_URL}"; then
+              echo "Server answered after ${SECONDS}s"
+              exit 0
+            fi
+            if ! kill -0 "${HUGO_PID}" 2>/dev/null; then
+              echo "Hugo exited before serving anything:"
+              tail -n 50 hugo-server.log
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "No 200 from ${SERVER_URL} within 300s:"
+          tail -n 50 hugo-server.log
+          exit 1
+
+      # `hugo server` does not build the search index, and dev-server.mjs only
+      # builds one for a server it STARTED — a DE_BASE_URL server gets a probe
+      # and nothing else. Without the index, PagefindUI is undefined on every
+      # page: with the conditional allowlist entry forced off, smoke failed 33
+      # of 33 `[2026-08-24, recorded in CLAUDE.md]`. The allowlist would quiet
+      # that, but then CI alone would never check the search UI. Same command
+      # the deploy workflows run; hugo serves docs/ from disk, so writing into
+      # it works.
+
+      - name: Build the search index with Pagefind
+        run: npx -y pagefind --site docs
+
+      # ---------------------------------------------------------------------
+      # the check
+      #
+      # DE_BASE_URL tells dev-server.mjs to trust this server and own nothing —
+      # it probes Pagefind and hands the URL straight back.
+      # ---------------------------------------------------------------------
+
+      - name: Run the smoke check
+        id: check
+        # No GITHUB_TOKEN here, and that is deliberate rather than forgotten.
+        # The characterization workflow needs one for its dataCommit lookup
+        # against api.github.com; this harness makes no network call of its own
+        # `[verified 2026-08-26: zero occurrences of api.github.com or
+        # GITHUB_TOKEN across smoke-pages.mjs, dev-server.mjs and
+        # site-urls.mjs]`. Its only subprocess is `git rev-parse HEAD`.
+        env:
+          DE_BASE_URL: ${{ env.SERVER_URL }}
+        run: |
+          # inputs.scope is empty on a pull_request event, so PRs get the full sweep
+          args="--report scripts/smoke-reports/"
+          if [ "${{ inputs.scope }}" != "sample" ]; then
+            args="$args --all"
+          fi
+          echo "node scripts/smoke-pages.mjs $args"
+          node scripts/smoke-pages.mjs $args
+
+      # The failing pages and their grouped signatures are in the step log;
+      # the JSON is for diffing locally. scripts/smoke-reports/ is gitignored
+      # (.gitignore:93) and exists only on the runner.
+      #
+      # NOT `if: failure()`. A job cancelled by `timeout-minutes` skips a
+      # failure() step while still running an always() one — measured, not
+      # assumed `[run 32802721473, 2026-08-25, on the characterization
+      # workflow: the timeout skipped its upload and ran the teardown beside
+      # it]` — and a timed-out run is exactly when the capture is most worth
+      # having. Gating on the check step's own outcome also fails safe: if a
+      # cancelled step leaves `outcome` unset, the comparison is still not
+      # 'success', so the upload runs.
+      #
+      # No include-hidden-files: that flag is in the characterization workflow
+      # for .sc-check, a DOT directory the action skips by default. Smoke
+      # writes no dot path, so its absence here is correct rather than an
+      # oversight.
+      - name: Upload the smoke report
+        if: always() && steps.check.outcome != 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: smoke-${{ github.run_id }}
+          path: |
+            scripts/smoke-reports/
+            hugo-server.log
+          retention-days: 14
+          if-no-files-found: warn
+
+      # `npx hugo server` leaves HUGO_PID somewhere above the binary, and two
+      # attempts to reach it by descent both failed on the characterization
+      # workflow: killing HUGO_PID alone `[run 32771116783]`, then killing its
+      # direct children as well `[run 32777189174]`. Both ended with the runner
+      # reporting "Terminate orphan process: (hugo)". Match by name instead:
+      # this runner is ephemeral and single-purpose, so the only hugo on it is
+      # the one this job started.
+
+      - name: Stop the Hugo server
+        if: always()
+        run: |
+          pkill -TERM -x hugo 2>/dev/null || true
+          kill -TERM "${HUGO_PID}" 2>/dev/null || true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -296,3 +296,195 @@ jobs:
         run: |
           pkill -TERM -x hugo 2>/dev/null || true
           kill -TERM "${HUGO_PID}" 2>/dev/null || true
+
+  # ---------------------------------------------------------------------
+  # was the base branch already red?
+  #
+  # Smoke's external failure sources are stronger than the characterization
+  # check's, not weaker. Pages fetch EHDP-data from raw GitHub URLs at runtime,
+  # so a renamed data file throws in the browser with nothing in this repo
+  # having changed; pages embed third parties that go down; and CLAUDE.md
+  # records an AirNow CORS error appearing on (home) once between two passes on
+  # an unchanged tree `[verified 2026-08-17]`. So a red sweep above is not by
+  # itself a regression in the PR. This job is the disconfirming test: rebuild
+  # the site from the BASE branch and run the same harness against it, minutes
+  # later and therefore against the same EHDP-data and the same third parties.
+  #
+  #   green here -> the base is fine, so this PR caused it
+  #   red here   -> the base is red too, so the world moved and the PR is
+  #                 probably innocent
+  #
+  # ONLY THE SITE SOURCE COMES FROM THE BASE. The harness stays at this PR's
+  # head on purpose, and here that matters more than it does for the
+  # characterization workflow: KNOWN_NOISE lives INSIDE smoke-pages.mjs, so a
+  # PR that adds an allowlist entry would otherwise have its control run
+  # without that entry, and the two runs would not be comparable. Task 1's
+  # BLOCKED_HOSTS route is in the same file and travels with it.
+  #
+  # base.sha is the BASE BRANCH TIP, not the merge base `[verified 2026-08-24
+  # on PR #1480: baseRefOid is production's tip, where git merge-base differs]`.
+  # The tip is the right control — it is what this PR merges into and what is
+  # deployed — and it needs no history, where a real merge base would need
+  # fetch-depth 0.
+  # ---------------------------------------------------------------------
+
+  base-control:
+    name: Was the base branch red too?
+    needs: smoke
+    if: failure() && github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+
+    # Same placeholder as the sweep, and unmeasured for the same reason. This
+    # job additionally does two checkouts and two npm ci, so it is the slower
+    # of the two. Task 6 sets both from Task 5's numbers.
+    timeout-minutes: 30
+
+    concurrency: # its own group — sharing the sweep's would have the two cancel each other
+      group: ${{ github.workflow }}-base-${{ github.ref_name }}
+      cancel-in-progress: true
+
+    steps:
+
+      - name: Checkout this PR (the harness and its allowlist)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Checkout the base branch tip (the site under test)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          fetch-depth: 1
+
+      - name: Set up node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      # Two installs, because the two trees play different parts: the root runs
+      # the harness and needs playwright, and base/ builds the site and needs
+      # ITS OWN locked hugo-extended — the point is the site that commit builds.
+
+      - name: Install dependencies (this PR, for the harness)
+        run: npm ci
+
+      - name: Install dependencies (base branch, for its Hugo)
+        working-directory: base
+        run: npm ci
+
+      - name: Confirm the base branch's locked Hugo is present
+        working-directory: base
+        run: npx hugo version
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Start the base branch's Hugo server
+        working-directory: base
+        run: |
+          npx hugo server \
+            --environment prod_prod \
+            --cleanDestinationDir \
+            --disableFastRender \
+            -p "${SERVER_PORT}" > ../hugo-server-base.log 2>&1 &
+          echo "HUGO_PID=$!" >> "$GITHUB_ENV"
+
+      # Bounded by the clock for the same reason as the sweep above: Hugo
+      # accepts the connection BEFORE the build finishes and holds it open, so
+      # one curl can block for as long as the build takes and counting attempts
+      # measures nothing.
+
+      - name: Wait for the server
+        run: |
+          deadline=$(( SECONDS + 300 ))
+          while [ "${SECONDS}" -lt "${deadline}" ]; do
+            if curl -fsS --max-time 120 -o /dev/null "${SERVER_URL}"; then
+              echo "Server answered after ${SECONDS}s"
+              exit 0
+            fi
+            if ! kill -0 "${HUGO_PID}" 2>/dev/null; then
+              echo "Hugo exited before serving anything:"
+              tail -n 50 hugo-server-base.log
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "No 200 from ${SERVER_URL} within 300s:"
+          tail -n 50 hugo-server-base.log
+          exit 1
+
+      - name: Build the search index with Pagefind
+        run: npx -y pagefind --site base/docs
+
+      # Same reason as the sweep job's: without the index every Pagefind error
+      # is allowlisted, and a control that cannot fail exonerates nothing.
+
+      - name: Confirm Pagefind is served
+        run: curl -fsS -o /dev/null "${SERVER_URL}pagefind/pagefind.js"
+
+      # continue-on-error, because RED here is a FINDING rather than a failure
+      # of this job — it is the outcome that exonerates the PR. `outcome` is the
+      # result BEFORE continue-on-error is applied, which is what makes the
+      # verdict below readable
+      # `[docs.github.com/en/actions/reference/workflows-and-actions/contexts,
+      # read 2026-08-24]`.
+      #
+      # No GITHUB_TOKEN, for the same reason as the sweep job: this harness
+      # makes no API call.
+
+      - name: Run this PR's harness against the base branch's site
+        id: control
+        continue-on-error: true
+        env:
+          DE_BASE_URL: ${{ env.SERVER_URL }}
+        run: node scripts/smoke-pages.mjs --all --report scripts/smoke-reports/
+
+      - name: Verdict
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          OUTCOME: ${{ steps.control.outcome }}
+        run: |
+          {
+            echo "### Base-branch control"
+            echo
+            echo "The sweep failed. This job rebuilt the site from \`${BASE_SHA}\` — the tip of"
+            echo "\`${BASE_REF}\` — and ran THIS PR's harness against it, so the only thing that"
+            echo "differs between the two runs is the site source. The allowlist and the blocked"
+            echo "hosts are the same in both."
+            echo
+            if [ "${OUTCOME}" = "success" ]; then
+              echo "**The base branch is GREEN.** A data rename or a third-party outage is not the"
+              echo "explanation; this PR's changes are. Read the \`signatures\` array in the sweep's"
+              echo "artifact — it groups the failures by exact error text, so it says at a glance"
+              echo "whether one error is site-wide or confined to a single template."
+            else
+              echo "**The base branch is RED too.** \`${BASE_REF}\` already fails against today's"
+              echo "EHDP-data and today's third parties, so this is probably not yours. Compare the"
+              echo "two \`signatures\` arrays: an error text present in BOTH runs is the world"
+              echo "moving, and one present only in the sweep is this PR's."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only when the base is red, and only then is there anything to compare
+      # against the sweep's own artifact. No include-hidden-files: smoke writes
+      # no dot path.
+
+      - name: Upload the base branch's smoke report
+        if: steps.control.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: smoke-base-${{ github.run_id }}
+          path: |
+            scripts/smoke-reports/
+            hugo-server-base.log
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Stop the Hugo server
+        if: always()
+        run: |
+          pkill -TERM -x hugo 2>/dev/null || true
+          kill -TERM "${HUGO_PID}" 2>/dev/null || true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -100,17 +100,27 @@ jobs:
     name: Load every page and fail on a console error
     runs-on: ubuntu-24.04
 
-    # PLACEHOLDER, and knowingly unmeasured — no smoke sweep has ever been
-    # timed on a runner. The only figure derivable without measuring is a
-    # floor, and it comes from the harness's own constant rather than from the
-    # system: visit() does a fixed 2s settle per page, so 925 pages at
-    # concurrency 6 spend 308s in settle alone, before any navigation.
-    # ubuntu-24.04 reports 4 logical processors, so
+    # 2.4x the measured job, the same multiple site-characterization.yml uses,
+    # rounded up. Measured on the calibration run `[run 33019503991,
+    # 2026-08-26]`: 62s to a serving prod_prod build, 2s for Pagefind, 427s for
+    # the 925-page sweep at concurrency 6, ~73s of checkout and setup, and
+    # 9m26s in total once the checkout anomaly below is excluded (862s less
+    # the 296s by which that fetch exceeded its sibling's). 2.4 x 9m26s is
+    # 22.6, rounded to 25, and the observed 14m22s still fits with headroom.
+    #
+    # THE MULTIPLE IS TAKEN ON 9m26s, NOT ON THE 14m22s THAT RUN ACTUALLY TOOK.
+    # `git fetch --depth=1` of the merge ref took 5m14s in that job, and that is
+    # not repo size: the characterization job fetched the SAME merge ref two
+    # seconds earlier and took 22s. One observation, cause unknown. Baking it
+    # into the ceiling would buy 10 more minutes of runner before a genuine hang
+    # is caught, which is the one thing this line exists to do.
+    #
+    # The sweep's own floor comes from the harness rather than the system:
+    # visit() does a fixed 2s settle per page, so 925 pages at concurrency 6
+    # spend 308s in settle alone. ubuntu-24.04 reports 4 logical processors, so
     # min(24, max(6, availableParallelism())) floors at 6 here
     # `[run 32777189174: "Concurrency: 6 (4 logical processors)"]`.
-    # Task 5 of documents/smoke-workflow-plan-2026-08-26.md reads the real
-    # number off the first run and Task 6 replaces this line with it.
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     concurrency: # one run per ref; a superseded PR push doesn't need its own sweep
       group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -334,10 +344,12 @@ jobs:
     if: failure() && github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
 
-    # Same placeholder as the sweep, and unmeasured for the same reason. This
-    # job additionally does two checkouts and two npm ci, so it is the slower
-    # of the two. Task 6 sets both from Task 5's numbers.
-    timeout-minutes: 30
+    # Same 25 as the sweep, from the same run. This job was expected to be the
+    # slower of the two — two checkouts and two npm ci — and measured, it is
+    # not: 9m36s against the sweep's 14m22s, and against its 9m26s once the
+    # sweep's 5m14s fetch anomaly is excluded. The two npm ci cost ~19s
+    # together and the second checkout 22s `[run 33019503991, 2026-08-26]`.
+    timeout-minutes: 25
 
     concurrency: # its own group — sharing the sweep's would have the two cancel each other
       group: ${{ github.workflow }}-base-${{ github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,13 @@ build runs either way, so `sample` narrows what is checked and does not make the
 two `:env` scripts share :8090 and so cannot run concurrently; each refuses to start when the other
 holds it.
 
+**CI runs the full sweep on every PR into `production`.** `.github/workflows/smoke.yml` builds
+`prod_prod` on the runner, builds Pagefind and then *asserts* the index is served, and sweeps every
+page; `workflow_dispatch` offers the 33-page sample instead. A failing sweep triggers a
+`base-control` job that rebuilds the site from the base branch tip and runs **this PR's harness**
+against it — green means the PR caused it, red means the data or a third party moved. The harness
+aborts `www.googletagmanager.com`, so no sweep reports page views to Google Analytics.
+
 Eight things to know before trusting a result:
 
 - **`npm run smoke -- --all` does not work here.** PowerShell eats the `--`, so the script gets an empty `argv` and silently runs the curated list — a pass you would read as full coverage. That is why `--all` has its own npm script. Direct `node scripts/smoke-pages.mjs --all --concurrency 12` works from either shell.

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,9 +1,10 @@
 # Automatic smoke check in GitHub Actions
 
-**Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Tasks 2–6 not started.** Branch
-`feature-smoke-GHA`, cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan
-had wrong — its own prescribed proof, and the claim that `dev_prod` emits no analytics tag — both
-rewritten in place below.
+**Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Task 2 written at `c7a3b3b223` but
+In progress — only Task 5's run proves it. Tasks 3–6 not started.** Branch `feature-smoke-GHA`,
+cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan had wrong — its own
+prescribed proof, and the claim that `dev_prod` emits no analytics tag — both rewritten in place
+below. Tasks 3 and 4 edit `.github/workflows/smoke.yml`, the file Task 2 created.
 
 Derive what a status line cannot hold:
 
@@ -122,7 +123,7 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 | # | Step | Commit | Status | Proof that ran |
 |---|---|---|---|---|
 | 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | `feature-smoke-GHA @ 6ebc18374c` | **DONE 2026-08-26** | Response-count arms 1→0, shipped-route arms 35→1, `smoke:prod_prod` 924/925 — below |
-| 2 | `.github/workflows/smoke.yml` — sweep job | — | **TODO** | `actionlint`; the first PR run |
+| 2 | `.github/workflows/smoke.yml` — sweep job | `feature-smoke-GHA @ c7a3b3b223` | **In progress** — file written; the run that proves it is Task 5 | YAML parses, pins and `paths-ignore` match the reference — below |
 | 3 | `smoke.yml` — Pagefind pre-flight assertion | — | **TODO** | Forced-absent arm, below |
 | 4 | `smoke.yml` — base-branch control job | — | **TODO** | Injected regression, below |
 | 5 | Calibration run: open the PR into `production`, read the wall time | — | **TODO** | The run's own step timings |
@@ -247,8 +248,16 @@ Different from it:
 - **`timeout-minutes: 30` as a placeholder**, with a comment saying it is unmeasured and that
   Tasks 5 and 6 replace it.
 
-**Proof:** `actionlint` if it is available. YAML alone proves little here — the real proof is
-Task 5, and this task is not done until that run exists.
+**Proof — static only, 2026-08-26.** `actionlint` is **not installed on this machine**, and
+neither PyYAML nor a node YAML package is present in the repo; the parse came from
+`npx -y js-yaml`, exit 0. Off the parsed document: one `smoke` job, 11 steps,
+`permissions: {contents: read}`, triggers `pull_request` and `workflow_dispatch`, the upload gated
+`always() && steps.check.outcome != 'success'`, and all three `uses:` pinned to 40-character SHAs.
+Cross-checked against `site-characterization.yml`: exactly three distinct action pins across both
+files, so the repo still has one pin per action, and `paths-ignore` diffs clean at 10 entries.
+
+None of that runs anything. **This task is not done until the Task 5 run exists** — the row above
+says **In progress** for that reason, not because anything is half-written.
 
 ## Task 3: Pagefind pre-flight assertion
 

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,10 +1,10 @@
 # Automatic smoke check in GitHub Actions
 
 **Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Task 2 written at `c7a3b3b223` but
-In progress — only Task 5's run proves it. Tasks 3–6 not started.** Branch `feature-smoke-GHA`,
+In progress — only Task 5's run proves it. Task 3 DONE at `7f5890799f`. Tasks 4–6 not started.** Branch `feature-smoke-GHA`,
 cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan had wrong — its own
 prescribed proof, and the claim that `dev_prod` emits no analytics tag — both rewritten in place
-below. Tasks 3 and 4 edit `.github/workflows/smoke.yml`, the file Task 2 created.
+below. Task 4 also edits `.github/workflows/smoke.yml`, the file Task 2 created and Task 3 extended.
 
 Derive what a status line cannot hold:
 
@@ -124,7 +124,7 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 |---|---|---|---|---|
 | 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | `feature-smoke-GHA @ 6ebc18374c` | **DONE 2026-08-26** | Response-count arms 1→0, shipped-route arms 35→1, `smoke:prod_prod` 924/925 — below |
 | 2 | `.github/workflows/smoke.yml` — sweep job | `feature-smoke-GHA @ c7a3b3b223` | **In progress** — file written; the run that proves it is Task 5 | YAML parses, pins and `paths-ignore` match the reference — below |
-| 3 | `smoke.yml` — Pagefind pre-flight assertion | — | **TODO** | Forced-absent arm, below |
+| 3 | `smoke.yml` — Pagefind pre-flight assertion | `feature-smoke-GHA @ 7f5890799f` | **DONE 2026-08-26** | 404 before the build / 200 after; `curl -f` exits 22 / 0 — below |
 | 4 | `smoke.yml` — base-branch control job | — | **TODO** | Injected regression, below |
 | 5 | Calibration run: open the PR into `production`, read the wall time | — | **TODO** | The run's own step timings |
 | 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | — | **TODO** | `npm run docs-check` with a stash control |
@@ -280,9 +280,22 @@ through the server rather than the filesystem, so it tests what the browser will
   run: curl -fsS -o /dev/null "${SERVER_URL}pagefind/pagefind.js"
 ```
 
-**Proof:** run that `curl` against a server whose `docs/pagefind/` has been removed and confirm it
-exits non-zero — a pre-flight that cannot fail is not a pre-flight. Then restore and confirm
-exit 0.
+**Proof — ran 2026-08-26.** The prescribed form said to remove `docs/pagefind/` from a live
+server. What ran instead inverts the order and never deletes anything under a running Hugo: curl
+the probe **before** the Pagefind build, then again after. Same two arms, and it is the order CI
+itself hits.
+
+| arm | HTTP | `curl -f` exit |
+|---|---|---|
+| before the Pagefind build | 404 | 22 |
+| after it | 200 | 0 |
+
+The 200 arm needed a control of its own. The first attempt read **exit 23 on a 200** and would have
+been recorded as a failing pre-flight: the probe invoked `curl` through Node's `spawnSync`, which
+bypasses Git Bash's `/dev/null` → `NUL` translation and hands a Windows binary a literal path, so
+the write failed while the request succeeded. Through a shell, `-o /dev/null` exits 0; the runner
+is Linux, where it is a real device. `curl -f` exiting 22 on a 404 and 0 on a 200 was then
+confirmed a second time against a synthetic local server, independent of Hugo.
 
 ## Task 4: The base-branch control job
 

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,0 +1,365 @@
+# Automatic smoke check in GitHub Actions
+
+**Status as of 2026-08-26: PLANNED. Nothing has landed.** Branch `feature-smoke-GHA`, cut from
+`production` at `9ebb11e85f`. Tasks 1–6 below are unstarted.
+
+Derive what a status line cannot hold:
+
+```
+git log --oneline 9ebb11e85f..HEAD                                   # the task commits
+git rev-list --left-right --count origin/production...HEAD           # right-hand number = unpushed
+gh pr list --head feature-smoke-GHA                                  # a PR, and against which base
+gh run list --workflow smoke.yml                                     # has the workflow ever run
+```
+
+## Why
+
+`scripts/smoke-pages.mjs` is the only check in this repo that runs the site's JavaScript. The
+site's browser JS is classic `<script>` tags sharing one global scope, so a bad edit throws at
+load while `hugo` still exits 0 — a build proves the templates compile and nothing more. Today
+that check runs only when someone remembers to run it.
+
+`site-characterization.yml` already automates the breadth-first structural counterpart on every PR
+into `production`. The two catch disjoint failures: characterization fails on a page whose
+rendered structure moved, smoke fails on a page whose JS threw. Neither sees what the other does.
+Automating one and not the other leaves the JS half on human memory.
+
+The second reason is specific to smoke and does not apply to the build: each environment pins its
+own `data_branch`, and pages `fetch` EHDP-data from raw GitHub URLs **at runtime**. A renamed data
+file throws in the browser and in nothing else. `prod_prod` pins `data_branch = "production"`
+(`config/prod_prod/config.toml`), which is the data the site deploys against.
+
+## Decisions taken
+
+- **`prod_prod`, with `www.googletagmanager.com` blocked in the harness.** Chosen 2026-08-26 over
+  `dev_prod`, which pins the same `data_branch` and emits no analytics tag at all.
+
+  `head.html:3-15` emits `gtag/js?id=G-64BWDRHRGB` and an inline `gtag('config', …)` **only** when
+  `hugo.Environment` is `prod_prod`. `site-characterization.mjs` aborts that host at the network
+  layer (`BLOCKED_HOSTS`, `:167-172`; the `page.route` that applies it, `:698-700`).
+  `smoke-pages.mjs` has no such route — a grep for `route`, `abort` and `googletagmanager` returns
+  nothing across the file `[2026-08-26]`. So a 925-page sweep under `prod_prod` has an unblocked
+  path to the live analytics property. **Not measured** that hits are sent, only that the
+  mechanism is present and unblocked; Task 1's positive control settles it.
+
+  This is a pre-existing local exposure, not one CI would create: `npm run smoke:prod_prod` has
+  the same unblocked path and was run twice on 2026-08-26
+  (`documents/smoke-env-plan-2026-08-26.md` Task 6).
+
+  Blocking rather than switching environment keeps two things `dev_prod` would cost: the inline
+  `gtag()` block is first-party JS that executes only under `prod_prod`, and it stays under test
+  because only the *external* script is aborted; and the CI environment stays identical to the
+  characterization workflow's, so a red smoke and a red characterization on one PR describe the
+  same site rather than two.
+
+- **Full 925-page sweep on `pull_request`, `sample` available on `workflow_dispatch`.** Matches
+  `site-characterization.yml`, which sweeps `--all` on every PR. CLAUDE.md's smoke section is
+  explicit that a curated pass proves nothing about a page kind absent from `PAGES`, and a
+  pre-merge sweep is the case `--all` exists for.
+
+- **A base-branch control job, gated on the sweep failing.** Smoke's external failure sources are
+  stronger than characterization's, not weaker: EHDP-data renames throw at runtime, third-party
+  embeds go down, and CLAUDE.md already records an AirNow CORS error appearing on `(home)` once
+  between two passes on an unchanged tree `[verified 2026-08-17]`. Rebuilding the base tip and
+  re-running the **same harness** separates "this PR broke it" from "the world moved".
+
+  Holding the harness at the PR's head matters more here than in the characterization workflow:
+  `KNOWN_NOISE` lives inside `smoke-pages.mjs`, so a PR that adds an allowlist entry would make a
+  wholesale-base-checkout control incomparable with the sweep it is controlling for.
+
+- **Its own workflow file, not a second job in `site-characterization.yml`.** Sharing one Hugo
+  build would save ~62s of build per run `[run 32771116783, 2026-08-24: 62s to a serving
+  prod_prod build]`, but the two sweeps would then run sequentially in one job — measured 370s for
+  characterization at concurrency 6, plus an unmeasured smoke sweep whose settle floor alone is
+  308s — against a `timeout-minutes` that already fired once on that workflow
+  `[run 32802721473, 2026-08-25]`. Separate files also keep the two failures separable in the PR
+  checks list.
+
+- **`production` now carries `smoke-pages.mjs`, and the base-control design does not rely on it.**
+  `git ls-tree --name-only production -- scripts/` lists `smoke-pages.mjs`, `smoke-env.mjs`,
+  `site-characterization.mjs` and `site-characterization-baseline` `[verified 2026-08-26]`. That
+  falsifies the comment in `site-characterization.yml`'s `base-control` job, which reads
+  "`production` carries neither `scripts/site-characterization.mjs` nor a baseline directory
+  `[verified 2026-08-24: git ls-tree production, both ABSENT]`" — true when written, made false by
+  PR #1482 and PR #1483. Task 6 corrects it. The split-checkout shape stays regardless, for the
+  `KNOWN_NOISE` reason above.
+
+- **`timeout-minutes` is set from a measurement, not before one.** No smoke sweep has ever been
+  timed at concurrency 6. Task 5 reads the real number off the first run and Task 6 writes it in.
+
+## What is NOT known
+
+- **The smoke sweep's wall time on a GitHub-hosted runner.** What is measured: 925 pages in 156s
+  *total*, including a cold `prod_prod` build and Pagefind, at concurrency 24 on a
+  24-logical-processor box `[2026-08-26, smoke-env-plan Task 6]`. `ubuntu-24.04` reports 4 logical
+  processors `[run 32777189174: "Concurrency: 6 (4 logical processors)"]`, so
+  `min(24, max(6, availableParallelism()))` floors at 6 there.
+
+  The only figure derivable without measuring is a floor, and it comes from the harness's own
+  constant rather than from the system: `visit()` does a fixed `page.waitForTimeout(2000)` per
+  page, so 925 pages at concurrency 6 spend **308s in settle alone**, before any navigation. For
+  scale, characterization swept the same 925 pages at concurrency 6 on the runner in 370s
+  *without* any settle `[run 32771116783, 2026-08-24]` — but that is a different harness, and
+  adding the two numbers is arithmetic, not a measurement. Task 5 measures it.
+
+- **Whether the sequential re-check fires within budget.** Below `RECHECK_CAP` (25) each failing
+  page is re-visited sequentially at the same 2s floor, so 25 failures add roughly a minute plus
+  navigation. Above 25 the re-check is skipped outright and the run says so — both branches are
+  proved to fire `[2026-08-26: same 33 forced failures at concurrency 4, cap 2 -> capped message
+  and no re-check, cap 100 -> sequential re-check ran]`.
+
+## Tasks
+
+| # | Step | Commit | Status | Proof that ran |
+|---|---|---|---|---|
+| 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | — | **TODO** | Two-arm request-count control, below |
+| 2 | `.github/workflows/smoke.yml` — sweep job | — | **TODO** | `actionlint`; the first PR run |
+| 3 | `smoke.yml` — Pagefind pre-flight assertion | — | **TODO** | Forced-absent arm, below |
+| 4 | `smoke.yml` — base-branch control job | — | **TODO** | Injected regression, below |
+| 5 | Calibration run: open the PR into `production`, read the wall time | — | **TODO** | The run's own step timings |
+| 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | — | **TODO** | `npm run docs-check` with a stash control |
+
+## Task 1: Block the analytics host in `smoke-pages.mjs`
+
+**Files:** `scripts/smoke-pages.mjs` — add a `BLOCKED_HOSTS` constant near `KNOWN_NOISE`
+(`:89-122`), and a `page.route` in `visit()` (`:203-227`) before `page.goto`.
+
+**Interfaces:** produces nothing for later tasks except the guarantee that Task 2's `prod_prod`
+sweep sends no analytics. Consumes nothing.
+
+Steps:
+
+1. Add the constant with a comment naming why this list is one host and not four:
+   `site-characterization.mjs` blocks the Google Translate hosts as well, because its baseline
+   records injected DOM and Translate injects on Google's network timing. Smoke reads console
+   errors, not DOM, so Translate's injection is not a churn source here — block only what has an
+   outward side effect.
+2. In `visit()`, register the route on the new page before navigating, aborting a request whose
+   host is in the list and continuing everything else. Same shape as
+   `site-characterization.mjs:698-700`.
+3. Note in the comment that the aborted request's own console error is already swallowed by the
+   existing broad `/favicon|Failed to load resource|net::ERR/i` entry, so this adds no failures —
+   and that this is the entry CLAUDE.md warns hides the *cause* of a blocked script.
+
+**Proof — a two-arm request-count control, because a request counter reading zero is exactly what
+a probe that never attached also reads.** Start one `prod_prod` server, then, in a scratch
+Playwright script that loads a single page and counts `request` events whose host is
+`www.googletagmanager.com`:
+
+- **arm A, route registered:** count must be 0.
+- **arm B, route commented out:** count must be **at least 1**. If arm B also reads 0 the
+  instrument is dead and arm A proves nothing — check the served HTML actually carries the gtag
+  `<script>` before believing either number.
+- **arm C, both arms:** the inline `gtag()` block must still produce no unallowlisted console
+  error, i.e. `npm run smoke:prod_prod` still passes 925/925.
+
+Record all three counts in the ledger row, not just arm A.
+
+## Task 2: The sweep job
+
+**Files:** new `.github/workflows/smoke.yml`.
+
+**Interfaces:** consumes Task 1's route. Produces the run whose timings Task 5 reads.
+
+Copy the structure of `site-characterization.yml`'s `characterize` job, which is the working
+example, and change only what differs. Same as it:
+
+- `on: pull_request: branches: [production, development]`, with the **same `paths-ignore` list,
+  copied verbatim** — `documents/**`, `memories/**`, `.claude/**`, `.agents/**`, `CLAUDE.md`,
+  `README.md`, `readme-components.md`, `readme-content.md`, `readme-development.md`, `LICENSE`.
+  Carry its warning across too: do not make this a required status check while it has a path
+  filter, because a workflow skipped by path filtering leaves its check Pending and blocks merging
+  `[docs.github.com, read 2026-08-24 — cited in site-characterization.yml]`.
+- `permissions: contents: read`.
+- `concurrency` group keyed on workflow + `github.ref_name`, `cancel-in-progress: true`.
+- `env: SERVER_PORT: 8080`, `SERVER_URL: http://localhost:8080/IndicatorPublic/`.
+- Checkout at `fetch-depth: 1`, `setup-node` 24.x with `cache: npm`, `npm ci`, `npx hugo version`,
+  `npx playwright install --with-deps chromium`.
+- Action `uses:` pinned to the **same commit SHAs already in `site-characterization.yml`** — one
+  pin per action across the repo, so a bump is one edit:
+  `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`,
+  `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`,
+  `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4`.
+- The server steps verbatim: start `npx hugo server --environment prod_prod
+  --cleanDestinationDir --disableFastRender -p "$SERVER_PORT"` into `hugo-server.log`, record
+  `HUGO_PID`, then the **clock-bounded** wait loop (300s deadline, `curl --max-time 120`,
+  `kill -0` liveness check). Keep the comment explaining why it is bounded by the clock and not by
+  an attempt count: Hugo accepts the connection before the build finishes and holds it open, so
+  one `curl` blocked for 61s inside a single iteration `[run 32771116783, 2026-08-24]`.
+- `npx -y pagefind --site docs`.
+- Teardown with `pkill -TERM -x hugo` plus the `HUGO_PID` kill, `if: always()`, and the comment
+  explaining that two attempts to reach the process by descent both failed.
+
+Different from it:
+
+- **No `GITHUB_TOKEN` in the check step's env.** Characterization needs it for the `dataCommit`
+  lookup against `api.github.com`. `smoke-pages.mjs` makes no API call — its only subprocess is
+  `git rev-parse HEAD` in `gitHead()` (`:258-264`). Say so in a comment, so the omission reads as
+  deliberate rather than forgotten.
+- **The check step** builds its arguments the way the characterization one does:
+
+  ```
+  args="--report scripts/smoke-reports/"
+  if [ "${{ inputs.scope }}" != "sample" ]; then args="$args --all"; fi
+  node scripts/smoke-pages.mjs $args
+  ```
+
+  with `DE_BASE_URL: ${{ env.SERVER_URL }}` — which takes `ensureDevServer`'s path 1, so the
+  script trusts this server, owns nothing, and probes Pagefind rather than building it
+  (`dev-server.mjs:182-199`). `inputs.scope` is empty on a `pull_request` event, so PRs get
+  `--all`. Give the workflow a `workflow_dispatch` with the same `scope: all|sample` choice input.
+- **Artifact:** `scripts/smoke-reports/` and `hugo-server.log`, gated
+  `if: always() && steps.check.outcome != 'success'` — never `if: failure()`, because a job
+  cancelled by `timeout-minutes` skips a `failure()` step while still running an `always()` one
+  `[run 32802721473, 2026-08-25]`. **No `include-hidden-files`**: that flag exists in the
+  characterization workflow for `.sc-check`, a dot directory, and smoke writes no dot path. Say
+  that in a comment so the next person does not read its absence as an oversight.
+  `scripts/smoke-reports/` is already gitignored (`.gitignore:92-93`).
+- **`timeout-minutes: 30` as a placeholder**, with a comment saying it is unmeasured and that
+  Tasks 5 and 6 replace it.
+
+**Proof:** `actionlint` if it is available. YAML alone proves little here — the real proof is
+Task 5, and this task is not done until that run exists.
+
+## Task 3: Pagefind pre-flight assertion
+
+**Files:** `.github/workflows/smoke.yml`, one step between the Pagefind build and the check.
+
+**Interfaces:** consumes Task 2's server; produces nothing.
+
+`KNOWN_NOISE` has one **conditional** entry — `{ page: null, error: /pagefind/i, when: () =>
+!pagefindServed }` (`smoke-pages.mjs:115`). If the index is absent, every Pagefind error on every
+page is allowlisted and the run goes green while blind. CLAUDE.md records what that hides: with
+the predicate forced off and no index, smoke failed 33 of 33, and the masked errors included
+`PagefindUI is not defined` on every page `[2026-08-24]`.
+
+A green CI run must therefore assert the index was actually served, not assume the build step
+worked. Add a step that curls the same asset `dev-server.mjs` probes (`PAGEFIND_PROBE`, `:67`) —
+through the server rather than the filesystem, so it tests what the browser will get:
+
+```
+- name: Confirm Pagefind is served
+  run: curl -fsS -o /dev/null "${SERVER_URL}pagefind/pagefind.js"
+```
+
+**Proof:** run that `curl` against a server whose `docs/pagefind/` has been removed and confirm it
+exits non-zero — a pre-flight that cannot fail is not a pre-flight. Then restore and confirm
+exit 0.
+
+## Task 4: The base-branch control job
+
+**Files:** `.github/workflows/smoke.yml`, second job `base-control`.
+
+**Interfaces:** consumes the sweep job's failure (`needs:` the sweep job, `if: failure() &&
+github.event_name == 'pull_request'`). Produces a `$GITHUB_STEP_SUMMARY` verdict.
+
+Copy `site-characterization.yml`'s `base-control` job, which is the working example, including:
+
+- Two checkouts — this PR at the root (the harness, `KNOWN_NOISE`, Task 1's route), and
+  `github.event.pull_request.base.sha` into `base/` (the site under test). `base.sha` is the base
+  **branch tip**, not the merge base `[verified 2026-08-24 on PR #1480]`; the tip is what the PR
+  merges into and needs no history, where a real merge base would need `fetch-depth: 0`.
+- Two `npm ci`, because the two trees play different parts: the root runs the harness and needs
+  Playwright, `base/` builds the site and needs its own locked `hugo-extended`.
+- Server started with `working-directory: base`, log to `../hugo-server-base.log`, the same
+  clock-bounded wait, `npx -y pagefind --site base/docs`.
+- The check step `continue-on-error: true` with an `id`, because RED here is a **finding**, not a
+  failure of this job — `outcome` is the result before `continue-on-error` is applied.
+- A `Verdict` step writing to `$GITHUB_STEP_SUMMARY`: green base means the PR caused it, red base
+  means the world moved and the PR is probably innocent.
+- Artifact upload gated on the control step's `outcome == 'failure'`.
+
+Two things to change from the characterization copy:
+
+1. The verdict prose. Smoke's "the world moved" causes are an EHDP-data rename that throws at
+   runtime, or a third-party embed being down — not a baseline mismatch. Say that, and point the
+   reader at the sweep artifact's `signatures` array, which groups failures by exact error text
+   and is the actionable half of the report (`smoke-pages.mjs:235-246`).
+2. Drop the stale claim that `production` carries no harness (see Decisions). Replace it with the
+   reason the split checkout still holds: `KNOWN_NOISE` is inside the harness, so a PR that adds
+   an allowlist entry must not have the control run without it.
+
+**Proof — the discriminating arm must edit the SITE SOURCE, not a shared input.** Both jobs run
+the same harness, so a change to `smoke-pages.mjs` moves both arms together and the test passes
+whichever way the mechanism works. On a throwaway branch, inject a one-line JS error into a shared
+template (a bad identifier in an inline `<script>` in `head.html`) and open a PR into
+`production`:
+
+- expected: sweep RED on hundreds of pages, `recheckCapped: true` in the report, base-control
+  **GREEN**, verdict reads "this PR's changes are".
+- Then run the other arm — an injection both arms share — only to confirm it goes **both-red**,
+  which is the branch that has never executed on the characterization workflow either.
+
+Write these two expectations down before the run, and check the result against them rather than
+reading the result to fit.
+
+## Task 5: Calibration run
+
+**Files:** none. This is a run, not an edit.
+
+Open the PR into `production`. Do **not** merge to test it: `hugo-build-to-prod-prod.yml` is
+`types: [closed]` with a `merged == true` guard, so a PR into `production` does not deploy, and
+`workflow_dispatch` will not register until the file is on the default branch anyway
+(CLAUDE.md, "Branching and deployment"). The PR's own `pull_request` run is the calibration.
+
+Record from the run's step timings, each as its own number:
+
+1. seconds to a serving `prod_prod` build (the wait step's own "Server answered after Ns"),
+2. the Pagefind build,
+3. the sweep,
+4. total job wall time,
+5. the concurrency and processor count the harness printed,
+6. `pagesChecked` and `recheckCapped` from the uploaded report, if it failed.
+
+**A green run proves only the unconditional steps.** The artifact upload, the base-control job and
+the Pagefind pre-flight's failing branch are all conditional and are proved by Tasks 3 and 4, not
+by this one.
+
+## Task 6: Set the timeout, docs, and the stale comment
+
+**Files:** `.github/workflows/smoke.yml`, `CLAUDE.md` (the Smoke test section),
+`.github/workflows/site-characterization.yml` (one comment).
+
+1. Replace the placeholder `timeout-minutes` with a figure derived from Task 5's measured total.
+   `site-characterization.yml` uses 2.4x its measured 8m13s; state the multiple and the
+   measurement it is a multiple of, so the next person can re-derive it.
+2. CLAUDE.md's Smoke test section: add that CI runs the full sweep on every PR into `production`
+   under `prod_prod`, that the harness blocks `www.googletagmanager.com`, and that a failure gets
+   a base-branch control job. Keep it to the section's existing bullet style.
+3. Correct `site-characterization.yml`'s `base-control` comment, which asserts `production`
+   carries neither the harness nor a baseline. Both are there now `[verified 2026-08-26:
+   git ls-tree --name-only production -- scripts/]`. Restate the design reason that survives —
+   holding the harness constant so only the site source varies.
+4. `readme-development.md`'s workflow table lists deploy workflows only and does not carry
+   `site-characterization.yml` `[verified 2026-08-26: a grep for .yml returns four table rows, all
+   hugo-build-*]`. Leave the smoke workflow out for consistency rather than adding one of two.
+
+**Proof:** `npm run docs-check` with a stash control — the pre-existing failures must be identical
+with and without these edits — plus an injected bogus path in one added sentence, to prove the
+zero-new-failures reading comes from a probe able to fire. Note that this worktree has never
+built, so `docs/` and `resources/_gen` are absent and `docs-check` reports two "path does not
+exist" failures on CLAUDE.md on a clean tree.
+
+## Environment state
+
+- Worktree `EH-dataportal.worktrees/feature-smoke-GHA`, branch cut from local `production` at
+  `9ebb11e85f`. Confirm no upstream is set: `git config --get branch.feature-smoke-GHA.merge`
+  should be empty.
+- Tasks 1 and 3 need a running `prod_prod` server. `smoke-env.mjs` and `characterize-env.mjs`
+  share :8090 and each refuses to start while the other holds it. If a run is interrupted, look
+  for a surviving `hugo.exe` before re-running — `TaskStop` does not reap the process tree.
+- Never run a second Hugo builder against this tree while one is up; `resources/_gen` is shared
+  and not namespaced by environment.
+
+## Deferred
+
+- **Sharding the sweep across runners.** If Task 5 shows the job is uncomfortably long,
+  `smoke-pages.mjs` has no shard flag and would need one (`--shard i/n` over `collectAllPaths`'s
+  output). Not worth building before there is a measured number saying it is needed.
+- **Rendering the `signatures` table into `$GITHUB_STEP_SUMMARY`.** The report JSON already
+  carries it; a small node step would turn a 900-line log into a table. Genuinely useful, entirely
+  cosmetic, and it should not delay the first working run.
+- **A smoke run against `dev_stage` as well.** The two environments pin different `data_branch`
+  values, so a staging-only data break is invisible to a `prod_prod`-only check.
+  `npm run smoke:env dev_stage` exists for it; whether CI should pay for a second full sweep is a
+  separate decision.

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,10 +1,13 @@
 # Automatic smoke check in GitHub Actions
 
 **Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Task 2 written at `c7a3b3b223` but
-In progress — only Task 5's run proves it. Task 3 DONE at `7f5890799f`. Task 4 written at `c37149d876`, also In progress — neither of its two proof arms has run. Tasks 5–6 not started.** Branch `feature-smoke-GHA`,
+In progress — only Task 5's run proves it. Task 3 DONE at `7f5890799f`. Task 4 written at `c37149d876`, also In progress — neither of its two proof arms has run. Task 5 not started. Task 6's three
+measurement-independent items landed at `52b7720bad`; its `timeout-minutes` item cannot run until
+Task 5 has.** Branch `feature-smoke-GHA`,
 cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan had wrong — its own
 prescribed proof, and the claim that `dev_prod` emits no analytics tag — both rewritten in place
-below. `.github/workflows/smoke.yml` now holds both jobs; Tasks 5 and 6 are the only ones left, and both need CI runs rather than edits.
+below. `.github/workflows/smoke.yml` now holds both jobs; what is left is Task 5's run and the one
+Task 6 item that reads a number off it.
 
 Derive what a status line cannot hold:
 
@@ -127,7 +130,7 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 | 3 | `smoke.yml` — Pagefind pre-flight assertion | `feature-smoke-GHA @ 7f5890799f` | **DONE 2026-08-26** | 404 before the build / 200 after; `curl -f` exits 22 / 0 — below |
 | 4 | `smoke.yml` — base-branch control job | `feature-smoke-GHA @ c37149d876` | **In progress** — job written; neither proof arm has run | Static only — the injected-regression arms need PRs — below |
 | 5 | Calibration run: open the PR into `production`, read the wall time | — | **TODO** | The run's own step timings |
-| 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | — | **TODO** | `npm run docs-check` with a stash control |
+| 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | `feature-smoke-GHA @ 52b7720bad` | **In progress** — items 2, 3 and 4 done; item 1 waits on Task 5's number | `docs-check`, four arms with a stash control and an injected bogus path — below |
 
 ## Task 1: Block the analytics host in `smoke-pages.mjs`
 
@@ -405,6 +408,28 @@ with and without these edits — plus an injected bogus path in one added senten
 zero-new-failures reading comes from a probe able to fire. Note that this worktree has never
 built, so `docs/` and `resources/_gen` are absent and `docs-check` reports two "path does not
 exist" failures on CLAUDE.md on a clean tree.
+
+**Status 2026-08-26: items 2, 3 and 4 done at `52b7720bad`. Item 1 is blocked on Task 5.**
+
+- **Item 3 — the stale comment.** Corrected in place rather than deleted: it now says the claim
+  was true when written on 2026-08-24, names PRs #1482 and #1483 as what falsified it, and keeps
+  the design reason that survives (only the site source comes from the base).
+- **Item 2 — CLAUDE.md.** One paragraph, ~75 words added to a 1299-word section.
+- **Item 4 — nothing to do.** `readme-development.md`'s workflow table lists deploy workflows only
+  and does not carry `site-characterization.yml`, so adding one of the two would be worse than
+  adding neither.
+
+**Proof that ran, on the tree that was committed:**
+
+| arm | `docs-check` failures |
+|---|---|
+| with the edits | 2 — `docs/`, `resources/_gen` |
+| stashed (control) | 2 — identical |
+| bogus path injected into an added sentence | 3 |
+| reverted | 2 |
+
+Both workflow files still parse under `npx -y js-yaml`. The two pre-existing failures are the ones
+this section already predicts for a worktree that has never built.
 
 ## Environment state
 

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,10 +1,10 @@
 # Automatic smoke check in GitHub Actions
 
 **Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Task 2 written at `c7a3b3b223` but
-In progress — only Task 5's run proves it. Task 3 DONE at `7f5890799f`. Tasks 4–6 not started.** Branch `feature-smoke-GHA`,
+In progress — only Task 5's run proves it. Task 3 DONE at `7f5890799f`. Task 4 written at `c37149d876`, also In progress — neither of its two proof arms has run. Tasks 5–6 not started.** Branch `feature-smoke-GHA`,
 cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan had wrong — its own
 prescribed proof, and the claim that `dev_prod` emits no analytics tag — both rewritten in place
-below. Task 4 also edits `.github/workflows/smoke.yml`, the file Task 2 created and Task 3 extended.
+below. `.github/workflows/smoke.yml` now holds both jobs; Tasks 5 and 6 are the only ones left, and both need CI runs rather than edits.
 
 Derive what a status line cannot hold:
 
@@ -125,7 +125,7 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 | 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | `feature-smoke-GHA @ 6ebc18374c` | **DONE 2026-08-26** | Response-count arms 1→0, shipped-route arms 35→1, `smoke:prod_prod` 924/925 — below |
 | 2 | `.github/workflows/smoke.yml` — sweep job | `feature-smoke-GHA @ c7a3b3b223` | **In progress** — file written; the run that proves it is Task 5 | YAML parses, pins and `paths-ignore` match the reference — below |
 | 3 | `smoke.yml` — Pagefind pre-flight assertion | `feature-smoke-GHA @ 7f5890799f` | **DONE 2026-08-26** | 404 before the build / 200 after; `curl -f` exits 22 / 0 — below |
-| 4 | `smoke.yml` — base-branch control job | — | **TODO** | Injected regression, below |
+| 4 | `smoke.yml` — base-branch control job | `feature-smoke-GHA @ c37149d876` | **In progress** — job written; neither proof arm has run | Static only — the injected-regression arms need PRs — below |
 | 5 | Calibration run: open the PR into `production`, read the wall time | — | **TODO** | The run's own step timings |
 | 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | — | **TODO** | `npm run docs-check` with a stash control |
 
@@ -343,6 +343,21 @@ template (a bad identifier in an inline `<script>` in `head.html`) and open a PR
 
 Write these two expectations down before the run, and check the result against them rather than
 reading the result to fit.
+
+**Status 2026-08-26: NEITHER ARM HAS RUN.** The job is written and committed; what exists is a
+static check only — YAML parses, `base-control` `needs: smoke` and is gated on `failure() &&
+github.event_name == 'pull_request'`, the control step carries `continue-on-error` and an `id`,
+the upload is gated on that step's `outcome`, there are two checkouts (root and `base/`), and
+`GITHUB_TOKEN` appears nowhere in the file. **Nothing about the verdict, the `needs:` gating, or
+the base checkout has been observed working.**
+
+Two departures from what this task specified, both deliberate:
+
+- The **Pagefind pre-flight from Task 3 is in this job too**, which the task's list did not ask
+  for. A control that cannot fail exonerates nothing, and without the index every Pagefind error
+  is allowlisted — the same argument the sweep's own pre-flight rests on.
+- `groupSignatures` is at **`smoke-pages.mjs:271-282`**, not the `:235-246` this task cited;
+  `RECHECK_CAP = 25` is at `:197`. Line numbers only.
 
 ## Task 5: Calibration run
 

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,12 +1,13 @@
 # Automatic smoke check in GitHub Actions
 
-**Status as of 2026-08-26: PLANNED. Nothing has landed.** Branch `feature-smoke-GHA`, cut from
-`production` at `9ebb11e85f`. Tasks 1–6 below are unstarted.
+**Status as of 2026-08-26: PLANNED. No task work has landed.** Branch `feature-smoke-GHA`, cut
+from `production` at `9ebb11e85f`. Tasks 1–6 below are unstarted; the only commit on the branch is
+the one carrying this document.
 
 Derive what a status line cannot hold:
 
 ```
-git log --oneline 9ebb11e85f..HEAD                                   # the task commits
+git log --oneline 9ebb11e85f..HEAD -- ':!documents/'                  # the task commits
 git rev-list --left-right --count origin/production...HEAD           # right-hand number = unpushed
 gh pr list --head feature-smoke-GHA                                  # a PR, and against which base
 gh run list --workflow smoke.yml                                     # has the workflow ever run

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,13 +1,16 @@
 # Automatic smoke check in GitHub Actions
 
-**Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Task 2 written at `c7a3b3b223` but
-In progress — only Task 5's run proves it. Task 3 DONE at `7f5890799f`. Task 4 written at `c37149d876`, also In progress — neither of its two proof arms has run. Task 5 not started. Task 6's three
-measurement-independent items landed at `52b7720bad`; its `timeout-minutes` item cannot run until
-Task 5 has.** Branch `feature-smoke-GHA`,
+**Status as of 2026-08-26: Tasks 1, 2, 3, 5 and 6 DONE. Task 4 In progress — one of its two
+proof arms has now run, the other has not.** The calibration run is `33019503991` on PR #1484,
+and it is what closed Task 2: the workflow swept 925 pages on a real `pull_request` into
+`production`. Task 4's `base-control` job fired on that run and took its **both-red** branch
+correctly — the branch global CLAUDE.md recorded as never having executed on either workflow. Its
+**discriminating** arm, base GREEN with the verdict reading "this PR's changes are", still has
+not run here. Branch `feature-smoke-GHA`,
 cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan had wrong — its own
 prescribed proof, and the claim that `dev_prod` emits no analytics tag — both rewritten in place
-below. `.github/workflows/smoke.yml` now holds both jobs; what is left is Task 5's run and the one
-Task 6 item that reads a number off it.
+below. `.github/workflows/smoke.yml` now holds both jobs, both at a measured `timeout-minutes: 25`.
+What is left is Task 4's discriminating arm, which needs a throwaway branch and a second PR.
 
 Derive what a status line cannot hold:
 
@@ -102,7 +105,17 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 
 ## What is NOT known
 
-- **The smoke sweep's wall time on a GitHub-hosted runner.** What is measured: 925 pages in 156s
+**Both items below were answered by `[run 33019503991]` on 2026-08-26 and are kept for the
+reasoning they record. Measured: the sweep took 427s and the whole job 14m22s; the sequential
+re-check fired on 3 pages and cleared 2 of them, well inside the cap.**
+
+- **The smoke sweep's wall time on a GitHub-hosted runner.** ~~Not known~~ — **427s**, in a
+  14m22s job `[run 33019503991]`. The 308s settle floor below was a real floor: the sweep came in
+  38% above it. Characterization's 370s for the same 925 pages *without* any settle is the
+  comparison the next bullet warned against adding to; measured side by side on this PR the two
+  sweeps were 427s and 375s.
+
+  The original reasoning, which stands: what had been measured was 925 pages in 156s
   *total*, including a cold `prod_prod` build and Pagefind, at concurrency 24 on a
   24-logical-processor box `[2026-08-26, smoke-env-plan Task 6]`. `ubuntu-24.04` reports 4 logical
   processors `[run 32777189174: "Concurrency: 6 (4 logical processors)"]`, so
@@ -115,7 +128,10 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
   *without* any settle `[run 32771116783, 2026-08-24]` — but that is a different harness, and
   adding the two numbers is arithmetic, not a measurement. Task 5 measures it.
 
-- **Whether the sequential re-check fires within budget.** Below `RECHECK_CAP` (25) each failing
+- **Whether the sequential re-check fires within budget.** ~~Not known~~ — it fired on 3 pages
+  and took 11s `[run 33019503991]`; 2 of the 3 cleared. `recheckCapped: false` on both jobs.
+
+  The original reasoning, which stands: below `RECHECK_CAP` (25) each failing
   page is re-visited sequentially at the same 2s floor, so 25 failures add roughly a minute plus
   navigation. Above 25 the re-check is skipped outright and the run says so — both branches are
   proved to fire `[2026-08-26: same 33 forced failures at concurrency 4, cap 2 -> capped message
@@ -126,11 +142,11 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 | # | Step | Commit | Status | Proof that ran |
 |---|---|---|---|---|
 | 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | `feature-smoke-GHA @ 6ebc18374c` | **DONE 2026-08-26** | Response-count arms 1→0, shipped-route arms 35→1, `smoke:prod_prod` 924/925 — below |
-| 2 | `.github/workflows/smoke.yml` — sweep job | `feature-smoke-GHA @ c7a3b3b223` | **In progress** — file written; the run that proves it is Task 5 | YAML parses, pins and `paths-ignore` match the reference — below |
+| 2 | `.github/workflows/smoke.yml` — sweep job | `feature-smoke-GHA @ c7a3b3b223` | **DONE 2026-08-26** | Swept 925 pages on a real `pull_request` — `[run 33019503991]`, below |
 | 3 | `smoke.yml` — Pagefind pre-flight assertion | `feature-smoke-GHA @ 7f5890799f` | **DONE 2026-08-26** | 404 before the build / 200 after; `curl -f` exits 22 / 0 — below |
-| 4 | `smoke.yml` — base-branch control job | `feature-smoke-GHA @ c37149d876` | **In progress** — job written; neither proof arm has run | Static only — the injected-regression arms need PRs — below |
-| 5 | Calibration run: open the PR into `production`, read the wall time | — | **TODO** | The run's own step timings |
-| 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | `feature-smoke-GHA @ 52b7720bad` | **In progress** — items 2, 3 and 4 done; item 1 waits on Task 5's number | `docs-check`, four arms with a stash control and an injected bogus path — below |
+| 4 | `smoke.yml` — base-branch control job | `feature-smoke-GHA @ c37149d876` | **In progress** — the both-red arm has run; the discriminating arm has not | `[run 33019503991]`: `OUTCOME: failure`, both-red branch taken, same signature on both sides — below |
+| 5 | Calibration run: open the PR into `production`, read the wall time | PR #1484, `[run 33019503991]` | **DONE 2026-08-26** | The run's own step timings — six numbers below |
+| 6 | Set `timeout-minutes` from Task 5; docs; correct the stale `site-characterization.yml` comment | items 2/3/4 `52b7720bad`, item 1 `09ef891c82` | **DONE 2026-08-26** | `docs-check` four arms for the docs; `js-yaml` for the timeout edit — below |
 
 ## Task 1: Block the analytics host in `smoke-pages.mjs`
 
@@ -227,8 +243,9 @@ Different from it:
 
 - **No `GITHUB_TOKEN` in the check step's env.** Characterization needs it for the `dataCommit`
   lookup against `api.github.com`. `smoke-pages.mjs` makes no API call — its only subprocess is
-  `git rev-parse HEAD` in `gitHead()` (`:258-264`). Say so in a comment, so the omission reads as
-  deliberate rather than forgotten.
+  `git rev-parse HEAD` in `gitHead()` — at `:294-300`, not the `:258-264` this task wrote, which
+  the file had already moved past. Say so in a comment, so the omission reads as deliberate rather
+  than forgotten.
 - **The check step** builds its arguments the way the characterization one does:
 
   ```
@@ -347,12 +364,40 @@ template (a bad identifier in an inline `<script>` in `head.html`) and open a PR
 Write these two expectations down before the run, and check the result against them rather than
 reading the result to fit.
 
-**Status 2026-08-26: NEITHER ARM HAS RUN.** The job is written and committed; what exists is a
-static check only — YAML parses, `base-control` `needs: smoke` and is gated on `failure() &&
-github.event_name == 'pull_request'`, the control step carries `continue-on-error` and an `id`,
-the upload is gated on that step's `outcome`, there are two checkouts (root and `base/`), and
-`GITHUB_TOKEN` appears nowhere in the file. **Nothing about the verdict, the `needs:` gating, or
-the base checkout has been observed working.**
+**Status 2026-08-26, AMENDED after `[run 33019503991]`: ONE ARM HAS NOW RUN — the both-red one,
+and it arrived on its own rather than by injection.** PR #1484's sweep failed on one page and
+`base-control` fired. Observed, not inferred: the Verdict step's own env records
+`OUTCOME: failure`, `BASE_SHA: 9ebb11e85f3f7e4c99d9eaf87cbde6741b49f550` and
+`BASE_REF: production` — which also confirms `base.sha` is the base **branch tip**, since
+`9ebb11e85f` is where this branch was cut from. The base artifact uploaded, and its gate is
+`outcome == 'failure'`, so it is a second independent witness to the same outcome. Both reports
+carry one identical signature, `t.datasetSourceUrl is not a function` on
+`data-features/heat-report-archive/2024/`, 1 of 925 on each side — which is the reading the
+both-red branch exists to produce, and it is the right one: a Datawrapper embed from an unblocked
+host, unchanged by this PR.
+
+That proves the `needs:` gating, the split checkout, the base build, the pre-flight, the control
+step's `continue-on-error` semantics and the else-branch of the verdict.
+
+**THE DISCRIMINATING ARM STILL HAS NOT RUN.** Base GREEN with the sweep RED — the branch whose
+verdict reads "this PR's changes are" — needs the site-source injection this task specifies, on a
+throwaway branch and a second PR. A both-red result cannot stand in for it: it exercises the
+`else`, and the failure it reports is one neither arm caused.
+
+One defect the run surfaced, in both workflows: **the base report's `gitHead` names the wrong
+commit.** Both artifacts record `edf2e17299`, the PR merge ref, because `gitHead()`
+(`smoke-pages.mjs:294-300`) runs `git rev-parse HEAD` in the process cwd — the root checkout —
+even when the site under test is `base/`. The two artifacts are indistinguishable by their
+recorded commit. `site-characterization.mjs:833-835` has the same shape, so its `_meta.json`
+misattributes the same way. Deferred, below.
+
+What existed before that run was a static check only — YAML parses, `base-control` `needs: smoke`
+and is gated on `failure() && github.event_name == 'pull_request'`, the control step carries
+`continue-on-error` and an `id`, the upload is gated on that step's `outcome`, there are two
+checkouts (root and `base/`), and `GITHUB_TOKEN` appears nowhere in the file. That static list is
+kept because it is what the run then confirmed: the verdict, the `needs:` gating and the base
+checkout have all now been observed working, which they had not been when this paragraph was
+first written.
 
 Two departures from what this task specified, both deliberate:
 
@@ -384,6 +429,40 @@ Record from the run's step timings, each as its own number:
 the Pagefind pre-flight's failing branch are all conditional and are proved by Tasks 3 and 4, not
 by this one.
 
+**RAN 2026-08-26 — PR #1484, `[run 33019503991]`, head `bb76986ecc`, merge ref `edf2e17299`.**
+The sweep went RED (1 of 925) and `base-control` fired, so this run also produced the first
+execution of two things the plan had recorded as never having run.
+
+The six numbers, off the step timings:
+
+| | sweep job | `base-control` |
+|---|---|---|
+| 1. seconds to a serving `prod_prod` build | **62s** | 60s |
+| 2. Pagefind build | 2s | 1s |
+| 3. the sweep | **427s** | 424s |
+| 4. job wall time | **14m22s** | 9m36s |
+| 5. concurrency | 6 | 6 |
+| 6. `pagesChecked` / `recheckCapped` | 925 / `false` | 925 / `false` |
+
+Run total 24m03s. All five predictions written before the run held: the server answered inside the
+300s deadline at the same 62s characterization measured, concurrency floored at 6, the Pagefind
+pre-flight returned 200, the sweep cleared the 308s settle floor, and
+`data-features/heat-report-archive/2024/` recurred.
+
+**The 14m22s carries a 5m14s outlier that is not repo size.** `git fetch --depth=1` of the merge
+ref ran 22:23:26 → 22:28:40 in the sweep job. The characterization job fetched the **same merge
+ref** two seconds earlier on its own runner and took 22s. One observation, cause unknown. The
+timeout is therefore taken as a multiple of 9m26s — the 862s job less the 296s by which that
+fetch exceeded its sibling's — and not of the 14m22s the run reported.
+
+**Two conditional paths executed for the first time.** The artifact upload on a failing sweep,
+gated `always() && steps.check.outcome != 'success'`, uploaded a **complete** payload in both jobs
+— the report JSON *and* `hugo-server.log`, 4 files across 2 artifacts. And `base-control` ran end
+to end: `needs: smoke` gating, both checkouts, both `npm ci`, the base server, the pre-flight, the
+control step, the verdict and the second artifact.
+
+**Neither of those is Task 4's discriminating arm.** See Task 4's status below.
+
 ## Task 6: Set the timeout, docs, and the stale comment
 
 **Files:** `.github/workflows/smoke.yml`, `CLAUDE.md` (the Smoke test section),
@@ -409,7 +488,22 @@ zero-new-failures reading comes from a probe able to fire. Note that this worktr
 built, so `docs/` and `resources/_gen` are absent and `docs-check` reports two "path does not
 exist" failures on CLAUDE.md on a clean tree.
 
-**Status 2026-08-26: items 2, 3 and 4 done at `52b7720bad`. Item 1 is blocked on Task 5.**
+**Status 2026-08-26: DONE. Items 2, 3 and 4 at `52b7720bad`; item 1 at `09ef891c82`.**
+
+- **Item 1 — the timeout.** `timeout-minutes: 25` on both jobs, from 2.4x 9m26s — the same
+  multiple `site-characterization.yml` takes on its own measured job, rounded up. The comment
+  states the multiple, the number it multiplies, and why that number is not the 14m22s the run
+  reported: the sweep job's `git fetch` took 5m14s where its sibling took 22s on the same merge
+  ref, and folding an unexplained outlier into the ceiling buys ten more minutes of runner before
+  a genuine hang is caught. The observed 14m22s still fits inside 25 with headroom.
+
+  The same edit retires a claim the run falsified. That comment said `base-control` "is the slower
+  of the two" because it does two checkouts and two `npm ci`; measured, it is faster — 9m36s
+  against 14m22s, and against 9m26s once the outlier comes out. The two `npm ci` cost ~19s
+  together and the second checkout 22s.
+
+  Proof: `npx -y js-yaml` exit 0, and off the parsed document both jobs read
+  `timeout-minutes: 25`, `permissions: {contents: read}` unchanged, 12 and 15 steps unchanged.
 
 - **Item 3 — the stale comment.** Corrected in place rather than deleted: it now says the claim
   was true when written on 2026-08-24, names PRs #1482 and #1483 as what falsified it, and keeps
@@ -443,6 +537,18 @@ this section already predicts for a worktree that has never built.
   and not namespaced by environment.
 
 ## Deferred
+
+- **`gitHead` in a base-control artifact names the wrong commit — both workflows.** Surfaced by
+  `[run 33019503991]`: the sweep's report and the base's both record `edf2e17299`, the PR merge
+  ref, so the two artifacts cannot be told apart by their recorded commit. `gitHead()` runs
+  `git rev-parse HEAD` in the process cwd, and the harness deliberately runs from the root
+  checkout while the site under test is `base/` — so the field is reporting the harness's commit
+  under a name that reads as the site's. `site-characterization.mjs:833-835` is the same shape.
+  The cheap fix is an env override the base-control job sets to
+  `${{ github.event.pull_request.base.sha }}`, which both harnesses would need. Not done here: it
+  edits a script that `production` already carries, and it is a separate change from this branch's
+  subject.
+
 
 - **Sharding the sweep across runners.** If Task 5 shows the job is uncomfortably long,
   `smoke-pages.mjs` has no shard flag and would need one (`--shard i/n` over `collectAllPaths`'s

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -1,8 +1,9 @@
 # Automatic smoke check in GitHub Actions
 
-**Status as of 2026-08-26: PLANNED. No task work has landed.** Branch `feature-smoke-GHA`, cut
-from `production` at `9ebb11e85f`. Tasks 1–6 below are unstarted; the only commit on the branch is
-the one carrying this document.
+**Status as of 2026-08-26: Task 1 DONE at `6ebc18374c`. Tasks 2–6 not started.** Branch
+`feature-smoke-GHA`, cut from `production` at `9ebb11e85f`. Task 1 corrected two things this plan
+had wrong — its own prescribed proof, and the claim that `dev_prod` emits no analytics tag — both
+rewritten in place below.
 
 Derive what a status line cannot hold:
 
@@ -33,10 +34,17 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 ## Decisions taken
 
 - **`prod_prod`, with `www.googletagmanager.com` blocked in the harness.** Chosen 2026-08-26 over
-  `dev_prod`, which pins the same `data_branch` and emits no analytics tag at all.
+  `dev_prod`.
 
-  `head.html:3-15` emits `gtag/js?id=G-64BWDRHRGB` and an inline `gtag('config', …)` **only** when
-  `hugo.Environment` is `prod_prod`. `site-characterization.mjs` aborts that host at the network
+  **CORRECTED 2026-08-26, during Task 1.** This bullet read "`dev_prod` … emits no analytics tag
+  at all", and that is false. `head.html` has an `else` branch (`:19-31`): every non-`prod_prod`
+  environment emits `gtag/js?id=G-PB98MPZ31B`. So `dev_prod` would have sent one page view per
+  page to the development property rather than none, and **every** local smoke run ever made
+  against `dev_stage` or `development` has been reporting to it. The decision stands — the block
+  is by host, so it covers both properties — but not for the reason given.
+
+  `head.html:3-15` emits `gtag/js?id=G-64BWDRHRGB` and an inline `gtag('config', …)` when
+  `hugo.Environment` is `prod_prod`, and `:19-31` emits the `G-PB98MPZ31B` pair otherwise. `site-characterization.mjs` aborts that host at the network
   layer (`BLOCKED_HOSTS`, `:167-172`; the `page.route` that applies it, `:698-700`).
   `smoke-pages.mjs` has no such route — a grep for `route`, `abort` and `googletagmanager` returns
   nothing across the file `[2026-08-26]`. So a 925-page sweep under `prod_prod` has an unblocked
@@ -113,7 +121,7 @@ file throws in the browser and in nothing else. `prod_prod` pins `data_branch = 
 
 | # | Step | Commit | Status | Proof that ran |
 |---|---|---|---|---|
-| 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | — | **TODO** | Two-arm request-count control, below |
+| 1 | Block `www.googletagmanager.com` in `smoke-pages.mjs` | `feature-smoke-GHA @ 6ebc18374c` | **DONE 2026-08-26** | Response-count arms 1→0, shipped-route arms 35→1, `smoke:prod_prod` 924/925 — below |
 | 2 | `.github/workflows/smoke.yml` — sweep job | — | **TODO** | `actionlint`; the first PR run |
 | 3 | `smoke.yml` — Pagefind pre-flight assertion | — | **TODO** | Forced-absent arm, below |
 | 4 | `smoke.yml` — base-branch control job | — | **TODO** | Injected regression, below |
@@ -142,19 +150,39 @@ Steps:
    existing broad `/favicon|Failed to load resource|net::ERR/i` entry, so this adds no failures —
    and that this is the entry CLAUDE.md warns hides the *cause* of a blocked script.
 
-**Proof — a two-arm request-count control, because a request counter reading zero is exactly what
-a probe that never attached also reads.** Start one `prod_prod` server, then, in a scratch
-Playwright script that loads a single page and counts `request` events whose host is
-`www.googletagmanager.com`:
+**Proof — CORRECTED 2026-08-26, the prescribed version could not work.** It said to count
+`request` events and expect **0** with the route registered. Playwright fires `request` for an
+*intercepted* request as well as a real one, so that counter reads 1 in both arms and a working
+route would have looked broken. The discriminating counter is `response`: a response is bytes
+coming back from Google. What ran, all against one isolated `prod_prod` server:
 
-- **arm A, route registered:** count must be 0.
-- **arm B, route commented out:** count must be **at least 1**. If arm B also reads 0 the
-  instrument is dead and arm A proves nothing — check the served HTML actually carries the gtag
-  `<script>` before believing either number.
-- **arm C, both arms:** the inline `gtag()` block must still produce no unallowlisted console
-  error, i.e. `npm run smoke:prod_prod` still passes 925/925.
+- **arm B — no route, home page.** requests=1, **responses=1**. Instrument alive; the served HTML
+  carries both the host and `gtag(`.
+- **arm A — route registered, home page.** requests=1, **responses=0**.
+- **arm B/A on `data-features/realtime-air-quality/`**, the page that behaved differently below:
+  unblocked it fetched **five** googletagmanager URLs, all 200 — the site's own `G-64BWDRHRGB`,
+  a third-party `gtm.js?id=GTM-L8ZB` from the AirNow widget, and three more chained from those.
+  Blocked: 2 top-level requests, **0 responses**; the other three never fire because the scripts
+  that would have requested them never load.
+- **arm A' — the SHIPPED registration, not a replica.** Arms A and B test a copy of the route, so
+  the two arms above say nothing about `smoke-pages.mjs` itself. An aborted request logs exactly
+  one console error, `Failed to load resource: net::ERR_FAILED`, whose text does **not** name the
+  host — so the instrument is the *count*, with the broad `net::ERR` allowlist entry temporarily
+  commented out and the curated 33-page list on `prod_prod`:
 
-Record all three counts in the ledger row, not just arm A.
+  | shipped route | `net::ERR_FAILED` total | pages failing |
+  |---|---|---|
+  | registered | 35 | 33 of 33 |
+  | commented out | 1 | 1 of 33 |
+
+  Per page, the delta is exactly +1 on 32 pages and +2 on `realtime-air-quality`, which is the
+  two top-level aborts measured above. The single error present in both arms is pre-existing.
+- **arm C — `npm run smoke:prod_prod`, everything restored.** 924 of 925 clean. The one failure is
+  `t.datasetSourceUrl is not a function` on `data-features/heat-report-archive/2024/`; that
+  identifier appears nowhere in this repo's JS or templates and the page embeds Datawrapper from
+  the unblocked `datawrapper.dwcdn.net`. **Not isolated by a control sweep** — the argument is
+  mechanism only: `BLOCKED_HOSTS` holds one host, which serves neither site nor Datawrapper code.
+  A second full sweep on a stashed tree would settle it.
 
 ## Task 2: The sweep job
 

--- a/scripts/smoke-pages.mjs
+++ b/scripts/smoke-pages.mjs
@@ -130,6 +130,36 @@ const isKnownNoise = (text, path) =>
     KNOWN_NOISE.some(({ page, error, when }) =>
         error.test(text) && (page === null || page.test(path)) && (when === undefined || when()));
 
+// Hosts whose requests visit() aborts before they leave the browser.
+//
+// One host, where site-characterization.mjs blocks four. The difference is what
+// each harness records: that one baselines injected DOM, so Google Translate
+// churns it by injecting on Google's network timing, and blocking Translate buys
+// stability. Smoke records console errors, not DOM, so Translate is not a churn
+// source here. Block only what has an outward side effect.
+//
+// gtag is that side effect, and it is NOT confined to prod_prod: head.html
+// emits a gtag/js script on every environment — G-64BWDRHRGB under prod_prod,
+// G-PB98MPZ31B from the `else` branch everywhere else. So an unblocked sweep
+// reports one page view per page to a real analytics property whichever
+// environment it runs against. Blocking by HOST rather than by id covers both,
+// and covers a third party that loads its own container: the AirNow widget on
+// data-features/realtime-air-quality/ pulls gtm.js?id=GTM-L8ZB, which is why
+// that page aborts two requests where every other page aborts one
+// `[measured 2026-08-26, prod_prod: unblocked, that page fetched five
+// googletagmanager URLs and all five returned 200]`.
+//
+// Only the external script is aborted, so the inline gtag() block still runs and
+// stays under test. The aborted request logs one console error per abort —
+// `Failed to load resource: net::ERR_FAILED`, which does not name the host —
+// and the broad `/favicon|Failed to load resource|net::ERR/i` entry above
+// already swallows it, so this adds no failures. That entry is also the one
+// whose CAUTION warns it hides the *cause* of a blocked script: if a run ever
+// shows an unexplained "X is not defined", check this list before the allowlist.
+const BLOCKED_HOSTS = [
+    "www.googletagmanager.com",
+];
+
 // Default browser concurrency for --all. Derived from the machine rather than
 // fixed, and the same formula site-characterization.mjs uses, so the repo's two
 // sweeps behave alike on the same box — the cores available differ by an order
@@ -209,6 +239,12 @@ const visit = async (browser, baseURL, path, userAgent) => {
     });
     page.on("pageerror", (err) => {
         if (!isKnownNoise(err.message, path)) errors.push(err.message);
+    });
+
+    // Registered before navigating, so the very first request is covered.
+    await page.route("**/*", (route) => {
+        const host = new URL(route.request().url()).host;
+        return BLOCKED_HOSTS.includes(host) ? route.abort() : route.continue();
     });
 
     try {


### PR DESCRIPTION
`scripts/smoke-pages.mjs` is the only check in this repo that runs the site's JavaScript, and today it runs only when someone remembers to. The site's browser JS is classic `<script>` tags sharing one global scope, so a bad edit throws at load while `hugo` still exits 0. `site-characterization.yml` already automates the breadth-first structural counterpart on every PR into `production`; the two catch disjoint failures.

## What lands

- `scripts/smoke-pages.mjs` aborts `www.googletagmanager.com` at the network layer, the same way `site-characterization.mjs` does. Every non-`prod_prod` environment emits a `gtag/js` tag as well (`head.html:19-31`), so local sweeps had an unblocked path to the development analytics property too.
- New `.github/workflows/smoke.yml`: a `prod_prod` build on the runner, Pagefind, then a full 925-page sweep on every `pull_request` into `production`. `workflow_dispatch` offers the 33-page sample.
- A Pagefind pre-flight assertion. `KNOWN_NOISE` has one conditional entry that allowlists every Pagefind error when the index is absent — without the assertion a green run cannot be distinguished from a blind one.
- A `base-control` job, gated on the sweep failing: it rebuilds the site from the base branch tip and runs **this PR's harness** against it. Green means the PR caused it; red means the data or a third party moved. Only the site source comes from the base, because `KNOWN_NOISE` lives inside the harness.
- One corrected comment in `site-characterization.yml`, and a paragraph in CLAUDE.md's smoke section.

## This PR is itself the calibration run

`timeout-minutes` is a placeholder 30. No smoke sweep has ever been timed on a GitHub-hosted runner, and the only figure derivable without measuring is a floor from the harness's own constant: `visit()` waits a fixed 2s per page, so 925 pages at concurrency 6 spend 308s in settle alone. This run's step timings supply the real number, and a follow-up commit sets the timeout from it.

Not merge-ready until that lands. Opening the PR is how the workflow gets exercised — a `pull_request` into `production` does not deploy, since `hugo-build-to-prod-prod.yml` is `types: [closed]` with a `merged == true` guard.

A green run here proves only the unconditional steps. The artifact upload, the `base-control` job and the pre-flight's failing branch are all conditional; the first two have never executed on either workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
