### PR TITLE
Stop a base-control artifact claiming the wrong commit

### DIFF
--- a/.github/workflows/site-characterization.yml
+++ b/.github/workflows/site-characterization.yml
@@ -423,6 +423,10 @@ jobs:
         env:
           DE_BASE_URL: ${{ env.SERVER_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # see the sweep job's note
+          # The harness runs from THIS checkout; the site it checks was built
+          # from base/. Without this the _meta.json records the PR merge ref
+          # and is indistinguishable from the sweep job's own.
+          SITE_UNDER_TEST_COMMIT: ${{ github.event.pull_request.base.sha }}
         run: node scripts/site-characterization.mjs --check --all
 
       - name: Verdict

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -451,6 +451,10 @@ jobs:
         continue-on-error: true
         env:
           DE_BASE_URL: ${{ env.SERVER_URL }}
+          # The harness runs from THIS checkout; the site it sweeps was built
+          # from base/. Without this the report records the PR merge ref and
+          # is indistinguishable from the sweep job's own report.
+          SITE_UNDER_TEST_COMMIT: ${{ github.event.pull_request.base.sha }}
         run: node scripts/smoke-pages.mjs --all --report scripts/smoke-reports/
 
       - name: Verdict

--- a/documents/smoke-workflow-plan-2026-08-26.md
+++ b/documents/smoke-workflow-plan-2026-08-26.md
@@ -549,6 +549,11 @@ this section already predicts for a worktree that has never built.
   edits a script that `production` already carries, and it is a separate change from this branch's
   subject.
 
+  **DONE 2026-08-26 on `feature-base-control-provenance` at `18a2ddb535`**, as its own branch off
+  `production` for the reason above. `SITE_UNDER_TEST_COMMIT` overrides `gitHead()` in both
+  harnesses, and only the two `base-control` jobs set it — a sweep job's checkout IS the site it
+  sweeps, so the git call is already right there.
+
 
 - **Sharding the sweep across runners.** If Task 5 shows the job is uncomfortably long,
   `smoke-pages.mjs` has no shard flag and would need one (`--shard i/n` over `collectAllPaths`'s

--- a/scripts/site-characterization.mjs
+++ b/scripts/site-characterization.mjs
@@ -830,7 +830,17 @@ const differingPaths = (dirA, dirB, only = null) => walk(dirA)
 // them. --check refuses the comparison rather than let that read as a finding.
 const META_FILE = "_meta.json";
 
+// The commit of the SITE UNDER TEST, which is not always the commit this
+// process runs from. A base-control CI job runs the harness out of the PR's
+// checkout while the site it sweeps is built from base/, so `git rev-parse
+// HEAD` there names the harness rather than the site — and the two artifacts
+// then agree on the one field meant to tell them apart `[run 33019503991,
+// 2026-08-26: the sweep's report and the base's both recorded edf2e17299, the
+// PR merge ref]`. That job passes the base sha in; everywhere else the working
+// directory IS the site's tree and the git call is right.
 const gitHead = () => {
+    const declared = process.env.SITE_UNDER_TEST_COMMIT;
+    if (declared) return declared;
     try {
         return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
     } catch {

--- a/scripts/smoke-pages.mjs
+++ b/scripts/smoke-pages.mjs
@@ -291,7 +291,17 @@ const writeReport = (target, report) => {
     console.log(`\nReport written to ${file}`);
 };
 
+// The commit of the SITE UNDER TEST, which is not always the commit this
+// process runs from. A base-control CI job runs the harness out of the PR's
+// checkout while the site it sweeps is built from base/, so `git rev-parse
+// HEAD` there names the harness rather than the site — and the two artifacts
+// then agree on the one field meant to tell them apart `[run 33019503991,
+// 2026-08-26: the sweep's report and the base's both recorded edf2e17299, the
+// PR merge ref]`. That job passes the base sha in; everywhere else the working
+// directory IS the site's tree and the git call is right.
 const gitHead = () => {
+    const declared = process.env.SITE_UNDER_TEST_COMMIT;
+    if (declared) return declared;
     try {
         return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
     } catch {


### PR DESCRIPTION
Both harnesses record `gitHead` by running `git rev-parse HEAD` in their own working directory. In a `base-control` job that directory is the PR's checkout, while the site under test was built from `base/` — so the field names the harness rather than the site, and the two artifacts agree on the one value meant to tell them apart.

Measured on the first CI run of `smoke.yml` (`[run 33019503991]`): the sweep's report and the base's **both recorded `edf2e17299`**, the PR merge ref. Filed at the time as Deferred in `documents/smoke-workflow-plan-2026-08-26.md`; that entry now names this branch.

## The change

`SITE_UNDER_TEST_COMMIT` overrides `gitHead()` in both harnesses, and only the two `base-control` jobs set it, to `github.event.pull_request.base.sha`.

The sweep jobs are deliberately left alone: there the checkout **is** the site under test, so the git call is already right, and setting the variable would only give it a second way to be wrong.

## Verification

Two arms over the shipped `smoke-pages.mjs`, against one isolated `prod_prod` server:

| arm | `gitHead` recorded |
|---|---|
| `SITE_UNDER_TEST_COMMIT` set | the declared value |
| unset (control) | `156693a99b`, the working tree's HEAD |

The arms differ, so the branch fires and the control is not degenerate. The YAML wiring is checked separately: four occurrences of the name repo-wide, identical, and both workflow hits sit in `base-control` rather than a sweep job.

## This PR is also the end-to-end test

`production` still carries the Datawrapper defect that PR #1485 fixes, so this PR's sweep will fail and `base-control` will run — which is the only way this code path executes. Written down before the run:

1. Sweep **red**, 1 of 925, `t.datasetSourceUrl is not a function` on `data-features/heat-report-archive/2024/`.
2. `base-control` fires and is **red too**; verdict reads "the base branch is RED too".
3. **The two artifacts record different `gitHead` values** — the sweep's the PR merge ref, the base's `156693a99b`. This is the claim under test.
4. Characterization **passes**; this branch changes no site source, so its own `base-control` stays skipped.

Merge order against #1485 does not matter — the two touch disjoint files. If #1485 merges first, prediction 1 stops holding and this path needs an injected failure to exercise instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
