### PR TITLE
Allowlist third-party Maps API error on displacement-risk in smoke

### DIFF
--- a/scripts/smoke-pages.mjs
+++ b/scripts/smoke-pages.mjs
@@ -97,6 +97,14 @@ const KNOWN_NOISE = [
     // makes a cross-origin XHR to airnowgovapi.com that the API serves without
     // an Access-Control-Allow-Origin header. Third-party embed, not our request.
     { page: /realtime-air-quality/, error: /airnowgovapi\.com|widget\.airnow\.gov/i },
+    // displacement-risk iframes NYC City Planning's Equitable Development Data
+    // Explorer (equitableexplorer.planning.nyc.gov, displacement.html:33), whose
+    // CARTO basemap key was rejected as of 2026-08-31: "Unauthorized access to
+    // Maps API: invalid combination of user ('planninglabs') and apiKey ...".
+    // Third-party embed we don't control; the surrounding page renders. Verified
+    // present on production's own tip via the smoke base-control job on PR #1489.
+    // Remove this when the embed loads again.
+    { page: /displacement-risk/, error: /Unauthorized access to Maps API/i },
     // The signup <iframe> in partials/header.html embeds a Google Form, which
     // Google serves with a report-only `frame-ancestors 'none'`. Chromium logs
     // the refusal on every page that renders the header. Report-only, so nothing


### PR DESCRIPTION
## What

`data-features/displacement-risk/` iframes NYC City Planning's Equitable
Development Data Explorer (`equitableexplorer.planning.nyc.gov`), embedded
at `themes/dohmh/layouts/data-features/displacement.html:33`. That
property's CARTO basemap key started returning:

```
Unauthorized access to Maps API: invalid combination of user ('planninglabs') and apiKey ('78658413...')
```

as of 2026-08-31. The smoke sweep counts it as a console error and fails
the run.

## Why allowlist rather than fix

It is a third-party embed we don't control — we only iframe it in. The
surrounding page renders fine. The smoke **base-control** job on #1489
rebuilt production's own tip and hit the identical failure, so this is
pre-existing and external, not a regression.

## Scope

`KNOWN_NOISE` entry scoped to `/displacement-risk/` (the `layout:
displacement` renders only that page), per the comment block above
`KNOWN_NOISE` in `scripts/smoke-pages.mjs` — a bug-specific signature
excused site-wide would swallow a real regression producing the same text
elsewhere. Same shape as the existing `realtime-air-quality` / AirNow
entry.

Remove the entry when the embed loads again.

## Verification

- `node -c scripts/smoke-pages.mjs` — parses
- error regex matches the observed console text; page regex matches the
  harness path form (`data-features/displacement-risk/`, as printed in
  the #1489 smoke log)
- CI smoke on this PR should now pass that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
